### PR TITLE
Support event field variations and improve week view resizing

### DIFF
--- a/planner_schema_patch.sql
+++ b/planner_schema_patch.sql
@@ -1,0 +1,39 @@
+-- === Planner Schema Patch (idempotent) ===
+-- Tasks: notes, has_time, due_date
+-- Events: title, notes, rrule
+
+-- 1) TASKS kolonları
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS notes    text NOT NULL DEFAULT '';
+
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS has_time boolean NOT NULL DEFAULT false;
+
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS due_date date NULL;
+
+-- 2) EVENTS kolonları
+ALTER TABLE IF EXISTS public.events
+  ADD COLUMN IF NOT EXISTS title text NULL;
+
+ALTER TABLE IF EXISTS public.events
+  ADD COLUMN IF NOT EXISTS notes text NOT NULL DEFAULT '';
+
+ALTER TABLE IF EXISTS public.events
+  ADD COLUMN IF NOT EXISTS rrule text NULL;
+
+-- 3) Faydalı indeksler
+CREATE INDEX IF NOT EXISTS idx_events_starts_at ON public.events (starts_at);
+CREATE INDEX IF NOT EXISTS idx_events_task_id  ON public.events (task_id);
+
+-- 4) Sadece zaman atanmamış görevler için opsiyonel view/index
+CREATE INDEX IF NOT EXISTS idx_tasks_unscheduled ON public.tasks (id)
+WHERE COALESCE(has_time, false) = false;
+
+CREATE OR REPLACE VIEW public.tasks_unscheduled AS
+SELECT *
+FROM public.tasks
+WHERE COALESCE(has_time, false) = false;
+
+-- NOT: updated_at trigger'ların zaten tanımlı.
+-- RLS kullanıyorsan, select/insert/update/delete policy'lerini ayrıca eklemeyi unutma.

--- a/widgets/calendar/week_view_editable.py
+++ b/widgets/calendar/week_view_editable.py
@@ -67,8 +67,20 @@ class CalendarWeekView(QtWidgets.QWidget):
         self._events.clear()
         for ev in events:
             try:
-                start = datetime.fromisoformat(ev["start"])
-                end = datetime.fromisoformat(ev["end"])
+                start_raw = (
+                    ev.get("start")
+                    or ev.get("start_ts")
+                    or ev.get("starts_at")
+                )
+                end_raw = (
+                    ev.get("end")
+                    or ev.get("end_ts")
+                    or ev.get("ends_at")
+                )
+                if not start_raw or not end_raw:
+                    continue
+                start = datetime.fromisoformat(str(start_raw).replace("Z", "+00:00"))
+                end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
             except Exception:
                 continue
             block = EventBlock(


### PR DESCRIPTION
## Summary
- Allow weekly calendar to keep minimum day width and enable horizontal scrolling when the window is narrow
- Parse `start_ts`/`starts_at` and `end_ts`/`ends_at` so fetched events render in the week view
- Use shared DB instance when editing tasks so changes appear immediately
- Document planner table changes in a schema patch SQL file

## Testing
- `python -m py_compile pages/planner_page.py widgets/calendar/week_view_editable.py`

------
https://chatgpt.com/codex/tasks/task_e_689bb1ee8a0c832886ab643b2967b2e5