### PR TITLE
Unify tasks and events under single task model

### DIFF
--- a/planner_schema_patch.sql
+++ b/planner_schema_patch.sql
@@ -1,6 +1,5 @@
 -- === Planner Schema Patch (idempotent) ===
--- Tasks: notes, has_time, due_date
--- Events: title, notes, rrule
+-- Tasks: notes, has_time, due_date, start_ts, end_ts
 
 -- 1) TASKS kolonları
 ALTER TABLE IF EXISTS public.tasks
@@ -12,21 +11,16 @@ ALTER TABLE IF EXISTS public.tasks
 ALTER TABLE IF EXISTS public.tasks
   ADD COLUMN IF NOT EXISTS due_date date NULL;
 
--- 2) EVENTS kolonları
-ALTER TABLE IF EXISTS public.events
-  ADD COLUMN IF NOT EXISTS title text NULL;
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS start_ts timestamptz NULL;
 
-ALTER TABLE IF EXISTS public.events
-  ADD COLUMN IF NOT EXISTS notes text NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS end_ts   timestamptz NULL;
 
-ALTER TABLE IF EXISTS public.events
-  ADD COLUMN IF NOT EXISTS rrule text NULL;
+-- 2) Faydalı indeksler
+CREATE INDEX IF NOT EXISTS idx_tasks_starts_at ON public.tasks (start_ts);
 
--- 3) Faydalı indeksler
-CREATE INDEX IF NOT EXISTS idx_events_starts_at ON public.events (starts_at);
-CREATE INDEX IF NOT EXISTS idx_events_task_id  ON public.events (task_id);
-
--- 4) Sadece zaman atanmamış görevler için opsiyonel view/index
+-- 3) Sadece zaman atanmamış görevler için opsiyonel view/index
 CREATE INDEX IF NOT EXISTS idx_tasks_unscheduled ON public.tasks (id)
 WHERE COALESCE(has_time, false) = false;
 

--- a/services/local_db.py
+++ b/services/local_db.py
@@ -24,23 +24,18 @@ class LocalDB:
             notes TEXT DEFAULT '',
             status TEXT DEFAULT 'todo',
             due_date TEXT,
+            start_ts TEXT,
+            end_ts   TEXT,
             has_time INTEGER DEFAULT 0,
             deleted INTEGER DEFAULT 0,
             created_at TEXT DEFAULT (datetime('now')),
             updated_at TEXT DEFAULT (datetime('now'))
         )""")
-        c.execute("""
-        CREATE TABLE IF NOT EXISTS events(
-            id INTEGER PRIMARY KEY,
-            task_id INTEGER,
-            title TEXT,
-            notes TEXT DEFAULT '',
-            start_ts TEXT NOT NULL,
-            end_ts   TEXT NOT NULL,
-            rrule TEXT,
-            deleted INTEGER DEFAULT 0,
-            updated_at TEXT DEFAULT (datetime('now'))
-        )""")
+        # Existing DB'lerde kolon ekle
+        try: c.execute("ALTER TABLE tasks ADD COLUMN start_ts TEXT")
+        except sqlite3.OperationalError: pass
+        try: c.execute("ALTER TABLE tasks ADD COLUMN end_ts TEXT")
+        except sqlite3.OperationalError: pass
         c.execute("""
         CREATE TABLE IF NOT EXISTS tags(
             id INTEGER PRIMARY KEY,
@@ -86,38 +81,20 @@ class LocalDB:
             self._conn.execute("DELETE FROM tasks")
             for t in rows or []:
                 self._conn.execute("""
-                    INSERT INTO tasks(id, title, notes, status, due_date, has_time, deleted, created_at, updated_at)
-                    VALUES(?,?,?,?,?,?,?,?,?)
+                    INSERT INTO tasks(id, title, notes, status, due_date, start_ts, end_ts, has_time, deleted, created_at, updated_at)
+                    VALUES(?,?,?,?,?,?,?,?,?,?,?)
                 """, (
                     t.get("id"),
                     t.get("title",""),
                     t.get("notes",""),
                     t.get("status","todo"),
                     t.get("due_date"),
+                    t.get("start_ts"),
+                    t.get("end_ts"),
                     int(t.get("has_time",0)),
                     int(t.get("deleted",0)) if "deleted" in t else 0,
                     t.get("created_at") or _now_iso(),
                     t.get("updated_at") or _now_iso(),
-                ))
-
-        elif table == "events":
-            self._conn.execute("DELETE FROM events")
-            for e in rows or []:
-                start_ts = e.get("start_ts") or e.get("starts_at")
-                end_ts   = e.get("end_ts")   or e.get("ends_at")
-                self._conn.execute("""
-                    INSERT INTO events(id, task_id, title, notes, start_ts, end_ts, rrule, deleted, updated_at)
-                    VALUES(?,?,?,?,?,?,?,?,?)
-                """, (
-                    e.get("id"),
-                    e.get("task_id"),
-                    e.get("title"),
-                    e.get("notes",""),
-                    start_ts,
-                    end_ts,
-                    e.get("rrule"),
-                    int(e.get("deleted",0)) if "deleted" in e else 0,
-                    e.get("updated_at") or _now_iso(),
                 ))
 
         elif table == "tags":
@@ -148,15 +125,11 @@ class LocalDB:
 
     def get_events(self) -> List[Dict[str, Any]]:
         rs = self._conn.execute("""
-            SELECT * FROM events
-            WHERE deleted=0
+            SELECT *, id as task_id FROM tasks
+            WHERE deleted=0 AND has_time=1 AND start_ts IS NOT NULL AND end_ts IS NOT NULL
             ORDER BY start_ts ASC
         """).fetchall()
         return [dict(r) for r in rs]
-
-    def get_event_by_id(self, ev_id: int) -> Optional[Dict[str, Any]]:
-        r = self._conn.execute("SELECT * FROM events WHERE id=?", (int(ev_id),)).fetchone()
-        return dict(r) if r else None
 
     def get_tags(self) -> List[Dict[str, Any]]:
         rs = self._conn.execute("SELECT * FROM tags").fetchall()
@@ -177,28 +150,34 @@ class LocalDB:
 
     # ---------------- TASKS ops ----------------
     def upsert_task(self, task_id: Optional[int], title: str, notes: str,
-                    due_date_iso: Optional[str], has_time: bool=False) -> int:
+                    due_date_iso: Optional[str], start_iso: Optional[str]=None,
+                    end_iso: Optional[str]=None) -> int:
+        has_time = int(bool(start_iso and end_iso))
         if task_id:
             self._conn.execute("""
-                UPDATE tasks SET title=?, notes=?, due_date=?, has_time=?, updated_at=?
+                UPDATE tasks SET title=?, notes=?, due_date=?, start_ts=?, end_ts=?, has_time=?, updated_at=?
                 WHERE id=?
-            """, (title, notes, due_date_iso, int(has_time), _now_iso(), int(task_id)))
+            """, (title, notes, due_date_iso, start_iso, end_iso, has_time, _now_iso(), int(task_id)))
             self._enqueue("tasks", "upsert", {
                 "id": int(task_id),
                 "title": title, "notes": notes,
-                "due_date": due_date_iso, "has_time": bool(has_time)
+                "due_date": due_date_iso,
+                "start_ts": start_iso, "end_ts": end_iso,
+                "has_time": bool(has_time)
             })
             tid = int(task_id)
         else:
             cur = self._conn.execute("""
-                INSERT INTO tasks(title, notes, due_date, has_time, created_at, updated_at)
-                VALUES(?,?,?,?,?,?)
-            """, (title, notes, due_date_iso, int(has_time), _now_iso(), _now_iso()))
+                INSERT INTO tasks(title, notes, due_date, start_ts, end_ts, has_time, created_at, updated_at)
+                VALUES(?,?,?,?,?,?,?,?)
+            """, (title, notes, due_date_iso, start_iso, end_iso, has_time, _now_iso(), _now_iso()))
             tid = int(cur.lastrowid)
             self._enqueue("tasks", "upsert", {
                 "id": tid,
                 "title": title, "notes": notes,
-                "due_date": due_date_iso, "has_time": bool(has_time)
+                "due_date": due_date_iso,
+                "start_ts": start_iso, "end_ts": end_iso,
+                "has_time": bool(has_time)
             })
         self._conn.commit()
         return tid
@@ -216,43 +195,15 @@ class LocalDB:
         self._enqueue("tasks", "upsert", {"id": int(task_id), "status": status})
         self._conn.commit()
 
-    def mark_task_has_time(self, task_id: int, has_time: bool):
-        self._conn.execute("UPDATE tasks SET has_time=?, updated_at=? WHERE id=?",
-                           (int(has_time), _now_iso(), int(task_id)))
-        self._enqueue("tasks", "upsert", {"id": int(task_id), "has_time": bool(has_time)})
-        self._conn.commit()
-
-    # ---------------- Events ops ----------------
-    def create_event(self, task_id: int, start_iso: str, end_iso: str,
-                     title: Optional[str]=None, notes: Optional[str]=None,
-                     rrule: Optional[str]=None) -> int:
-        cur = self._conn.execute("""
-            INSERT INTO events(task_id, title, notes, start_ts, end_ts, rrule, updated_at)
-            VALUES(?,?,?,?,?,?,?)
-        """, (int(task_id), title, notes or "", start_iso, end_iso, rrule, _now_iso()))
-        eid = int(cur.lastrowid)
-        self._enqueue("events", "upsert", {
-            "id": eid, "task_id": int(task_id), "title": title,
-            "notes": notes or "", "start_ts": start_iso, "end_ts": end_iso, "rrule": rrule
-        })
-        self._conn.commit()
-        return eid
-
-    def update_event(self, event_id: int, start_iso: str, end_iso: str,
-                     title: Optional[str]=None, notes: Optional[str]=None,
-                     rrule: Optional[str]=None):
+    def set_task_times(self, task_id: int, start_iso: Optional[str], end_iso: Optional[str]):
+        has_time = int(bool(start_iso and end_iso))
         self._conn.execute("""
-            UPDATE events SET start_ts=?, end_ts=?, title=?, notes=?, rrule=?, updated_at=?
+            UPDATE tasks SET start_ts=?, end_ts=?, has_time=?, updated_at=?
             WHERE id=?
-        """, (start_iso, end_iso, title, notes or "", rrule, _now_iso(), int(event_id)))
-        self._enqueue("events", "upsert", {
-            "id": int(event_id), "start_ts": start_iso, "end_ts": end_iso,
-            "title": title, "notes": notes or "", "rrule": rrule
+        """, (start_iso, end_iso, has_time, _now_iso(), int(task_id)))
+        self._enqueue("tasks", "upsert", {
+            "id": int(task_id),
+            "start_ts": start_iso, "end_ts": end_iso,
+            "has_time": bool(has_time)
         })
-        self._conn.commit()
-
-    def delete_event(self, event_id: int):
-        self._conn.execute("UPDATE events SET deleted=1, updated_at=? WHERE id=?",
-                           (_now_iso(), int(event_id)))
-        self._enqueue("events", "delete", {"id": int(event_id)})
         self._conn.commit()

--- a/services/sync_service.py
+++ b/services/sync_service.py
@@ -26,9 +26,9 @@ class SyncService(QtCore.QObject):
     @QtCore.pyqtSlot()
     def pull_all(self):
         try:
-            tasks  = api.fetch_tasks()
-            events = api.fetch_events()
-            tags   = api.fetch_tags()
+            tasks = api.fetch_tasks()
+            tags  = api.fetch_tags()
+            events = [t for t in tasks if t.get("has_time") and t.get("start_ts") and t.get("end_ts")]
             self.tasksUpdated.emit(tasks)
             self.eventsUpdated.emit(events)
             self.tagsUpdated.emit(tags)
@@ -46,12 +46,6 @@ class SyncService(QtCore.QObject):
 
     def delete_task(self, task_id: int) -> bool:
         return api.delete_task(task_id)
-
-    def upsert_event(self, ev: Dict[str, Any]) -> Dict[str, Any]:
-        return api.upsert_event(ev)
-
-    def delete_event(self, ev_id: int) -> bool:
-        return api.delete_event(ev_id)
 
     def upsert_tag(self, name: str, tag_id: int | None = None) -> Dict[str, Any]:
         return api.upsert_tag(name, tag_id)


### PR DESCRIPTION
## Summary
- treat events as tasks with optional `start_ts` and `end_ts` so all records live in the tasks table
- update APIs, sync layer and planner page to use unified task model and refresh calendar accordingly
- add schema changes to include start and end timestamps in `tasks`

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_689bbf368fa483289e7cdfe9934da963