### PR TITLE
feat: add drag-and-drop subtasks

### DIFF
--- a/services/supabase_api.py
+++ b/services/supabase_api.py
@@ -73,7 +73,7 @@ def delete_tag(tag_id: int) -> bool:
 
 # ---------------- TASKS ----------------
 
-TASK_FIELDS = "id,title,notes,status,tag_id,has_time,due_date,start_ts,end_ts,updated_at"
+TASK_FIELDS = "id,title,notes,status,tag_id,has_time,due_date,start_ts,end_ts,parent_id,updated_at"
 
 def fetch_tasks() -> list[dict]:
     _ensure()
@@ -108,6 +108,8 @@ def upsert_task(row: dict) -> dict:
         payload["start_ts"] = _zfix_ts(str(row.get("start_ts") or row.get("start") or row.get("starts_at")))
     if row.get("end_ts") or row.get("end") or row.get("ends_at"):
         payload["end_ts"] = _zfix_ts(str(row.get("end_ts") or row.get("end") or row.get("ends_at")))
+    if "parent_id" in row:
+        payload["parent_id"] = int(row["parent_id"]) if row["parent_id"] is not None else None
 
     r = requests.post(
         url,

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -71,8 +71,8 @@ class SyncOrchestrator(QtCore.QObject):
     # ---------- TASKS ----------
     def upsert_task(self, task_id: Optional[int], title: str, notes: str,
                     due_date_iso: Optional[str], start_iso: Optional[str]=None,
-                    end_iso: Optional[str]=None) -> int:
-        tid = self.db.upsert_task(task_id, title, notes, due_date_iso, start_iso=start_iso, end_iso=end_iso)
+                    end_iso: Optional[str]=None, parent_id: Optional[int]=None) -> int:
+        tid = self.db.upsert_task(task_id, title, notes, due_date_iso, start_iso=start_iso, end_iso=end_iso, parent_id=parent_id)
         self._emit_all_from_local()
         return tid
 
@@ -92,6 +92,14 @@ class SyncOrchestrator(QtCore.QObject):
     def set_task_times(self, task_id: int, start_iso: Optional[str], end_iso: Optional[str]):
         self.db.set_task_times(task_id, start_iso, end_iso)
         self._emit_all_from_local()
+
+    def set_task_parent(self, task_id: int, parent_id: Optional[int]):
+        self.db.set_task_parent(task_id, parent_id)
+        self.tasksUpdated.emit(self.db.get_tasks())
+        try:
+            api.upsert_task({"id": int(task_id), "parent_id": parent_id})
+        except Exception:
+            pass
 
     # ---------- helpers ----------
     def _emit_all_from_local(self):


### PR DESCRIPTION
## Summary
- allow dropping tasks onto another in Kanban board to set parent task
- track parent task in local DB and sync layers
- show parent selection on task dialog

## Testing
- `python -m py_compile services/local_db.py services/sync_orchestrator.py services/supabase_api.py kanban/board_lanes.py widgets/dialogs/event_task_dialog.py pages/planner_page.py`

------
https://chatgpt.com/codex/tasks/task_e_689bd262341883289ec8bbed9e51942d