### PR TITLE
Enable tag and project assignment with filtering

### DIFF
--- a/planner_schema_patch.sql
+++ b/planner_schema_patch.sql
@@ -17,6 +17,12 @@ ALTER TABLE IF EXISTS public.tasks
 ALTER TABLE IF EXISTS public.tasks
   ADD COLUMN IF NOT EXISTS end_ts   timestamptz NULL;
 
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS tag_id integer NULL;
+
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS project_id integer NULL;
+
 -- 2) Faydalı indeksler
 CREATE INDEX IF NOT EXISTS idx_tasks_starts_at ON public.tasks (start_ts);
 

--- a/services/sync_service.py
+++ b/services/sync_service.py
@@ -7,6 +7,7 @@ class SyncService(QtCore.QObject):
     tasksUpdated  = QtCore.pyqtSignal(list)
     eventsUpdated = QtCore.pyqtSignal(list)
     tagsUpdated   = QtCore.pyqtSignal(list)
+    projectsUpdated = QtCore.pyqtSignal(list)
     onlineChanged = QtCore.pyqtSignal(bool)
 
     def __init__(self, parent=None, poll_sec: int = 60):
@@ -28,10 +29,12 @@ class SyncService(QtCore.QObject):
         try:
             tasks = api.fetch_tasks()
             tags  = api.fetch_tags()
+            projects = api.fetch_projects()
             events = [t for t in tasks if t.get("has_time") and t.get("start_ts") and t.get("end_ts")]
             self.tasksUpdated.emit(tasks)
             self.eventsUpdated.emit(events)
             self.tagsUpdated.emit(tags)
+            self.projectsUpdated.emit(projects)
             if not self._online:
                 self._online = True
                 self.onlineChanged.emit(True)
@@ -52,3 +55,9 @@ class SyncService(QtCore.QObject):
 
     def delete_tag(self, tag_id: int) -> bool:
         return api.delete_tag(tag_id)
+
+    def upsert_project(self, name: str, project_id: int | None = None) -> Dict[str, Any]:
+        return api.upsert_project(name, project_id)
+
+    def delete_project(self, project_id: int) -> bool:
+        return api.delete_project(project_id)


### PR DESCRIPTION
## Summary
- store tag_id and project_id on tasks/events
- add project selection and filtering in planner UI
- support tag/project assignment in task/event dialog

## Testing
- `pytest`
- `python -m py_compile pages/planner_page.py services/local_db.py services/supabase_api.py services/sync_orchestrator.py services/sync_service.py widgets/core/selectors.py widgets/dialogs/event_task_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_689cd48e3f588328bff240f9203baa53