### PR TITLE
Allow toggling filters and sync new projects

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -396,7 +396,10 @@ class PlannerPage(QtWidgets.QWidget):
                 except Exception:
                     pass
         self.project_bar.setItems(items)
-        if not items:
+        ids = {pid for pid, _ in items}
+        if self._current_project in ids:
+            self.project_bar.setCurrentById(int(self._current_project))
+        else:
             self._current_project = None
 
     def _filter_tasks_and_update(self):
@@ -434,7 +437,7 @@ class PlannerPage(QtWidgets.QWidget):
         self._filter_events_and_update()
 
     def on_project_changed(self, project_id: int):
-        self._current_project = project_id
+        self._current_project = project_id or None
         self._filter_tasks_and_update()
         self._filter_events_and_update()
 

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -80,7 +80,11 @@ class SyncOrchestrator(QtCore.QObject):
 
     # ---------- PROJECTS ----------
     def add_project(self, name: str):
-        self.db.add_project_local(name)
+        pid = self.db.add_project_local(name)
+        try:
+            api.upsert_project(name, pid)
+        except Exception:
+            pass
         self.projectsUpdated.emit(self.db.get_projects())
 
     def delete_project(self, project_id: int):

--- a/widgets/core/selectors.py
+++ b/widgets/core/selectors.py
@@ -3,8 +3,11 @@ from PyQt6 import QtCore, QtWidgets
 from theme.colors import COLOR_TEXT, COLOR_SECONDARY_BG, COLOR_ACCENT
 
 class SlidingSelector(QtWidgets.QFrame):
-    """Dikey tek-seçim klasör listesi (şeffaf zemin, aktif= koyu gri arka plan)."""
-    changed = QtCore.pyqtSignal(int)  # seçilen id
+    """Dikey tek-seçim klasör listesi (şeffaf zemin, aktif= koyu gri arka plan).
+
+    Bir etikete tekrar tıklanınca seçimi kaldırıp tüm etiketleri gösterebilmek
+    için `changed` sinyali 0 değeri yayımlayabilir."""
+    changed = QtCore.pyqtSignal(int)  # seçilen id (0 = tümü)
 
     def __init__(self, parent=None, item_height=36, radius=12):
         super().__init__(parent)
@@ -66,11 +69,17 @@ class SlidingSelector(QtWidgets.QFrame):
             self._layout.addWidget(btn)
             self._id_order.append(_id)
         self._layout.addStretch(1)
-        # varsayılan ilkini seç
-        if self._id_order:
-            self.setCurrentById(self._id_order[0])
+        # başlangıçta hiçbirini seçme
+        self._current_id = None
 
     def _on_clicked(self, _id: int):
+        # Aynı butona tekrar tıklanınca seçimi kaldır
+        if self._current_id == _id:
+            if _id in self._buttons:
+                self._buttons[_id].setChecked(False)
+            self._current_id = None
+            self.changed.emit(0)
+            return
         self.setCurrentById(_id)
         self.changed.emit(_id)
 
@@ -90,8 +99,8 @@ class TagFolderList(SlidingSelector):
 
 
 class HorizontalSelector(QtWidgets.QFrame):
-    """Horizontal single-selection button row."""
-    changed = QtCore.pyqtSignal(int)
+    """Horizontal single-selection button row with toggle-off capability."""
+    changed = QtCore.pyqtSignal(int)  # 0 = tümü
 
     def __init__(self, parent=None, item_width: int = 100, item_height: int = 36):
         super().__init__(parent)
@@ -138,10 +147,16 @@ class HorizontalSelector(QtWidgets.QFrame):
             btn.clicked.connect(lambda _=False, i=_id: self._on_clicked(i))
             self._buttons[_id] = btn
             self._layout.addWidget(btn)
-        if items:
-            self.setCurrentById(items[0][0])
+        # başlangıçta seçim yok
+        self._current_id = None
 
     def _on_clicked(self, _id: int):
+        if self._current_id == _id:
+            if _id in self._buttons:
+                self._buttons[_id].setChecked(False)
+            self._current_id = None
+            self.changed.emit(0)
+            return
         self.setCurrentById(_id)
         self.changed.emit(_id)
 

--- a/widgets/layout/left_panel.py
+++ b/widgets/layout/left_panel.py
@@ -69,8 +69,13 @@ class LeftPanel(QtWidgets.QWidget):
 
     # ---- UI handlers ----
     def _on_tag_changed(self, tid: int):
-        self._current_tid = tid
-        self.tagsChanged.emit({tid})
+        if tid == 0:
+            # Seçim kaldırıldı -> tüm etiketler
+            self._current_tid = None
+            self.tagsChanged.emit(set())
+        else:
+            self._current_tid = tid
+            self.tagsChanged.emit({tid})
 
     def _toggle_new_bar(self):
         show = not self.new_bar.isVisible()


### PR DESCRIPTION
## Summary
- Sync newly created projects to the backend when added
- Allow tag and project buttons to toggle off to show all items
- Default tag and project lists to no selection

## Testing
- `python -m py_compile widgets/core/selectors.py widgets/layout/left_panel.py pages/planner_page.py services/sync_orchestrator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cdc0f21888328a113d25c436c1caf