### PR TITLE
Fix dynamic SQL quoting in schema patch

### DIFF
--- a/planner_schema_patch.sql
+++ b/planner_schema_patch.sql
@@ -48,11 +48,11 @@ BEGIN
     WHERE schemaname = 'public' AND tablename = 'tasks'
   ) THEN
     EXECUTE 'CREATE INDEX IF NOT EXISTS idx_tasks_starts_at ON public.tasks (start_ts)';
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_tasks_unscheduled ON public.tasks (id)
-      WHERE COALESCE(has_time, false) = false$$;
-    EXECUTE $$CREATE OR REPLACE VIEW public.tasks_unscheduled AS
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_tasks_unscheduled ON public.tasks (id)
+      WHERE COALESCE(has_time, false) = false';
+    EXECUTE 'CREATE OR REPLACE VIEW public.tasks_unscheduled AS
       SELECT * FROM public.tasks
-      WHERE COALESCE(has_time, false) = false$$;
+      WHERE COALESCE(has_time, false) = false';
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- avoid syntax errors in planner schema patch by using single-quoted EXECUTE statements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ceafcb3988328b7904f3a1cee1b78