### PR TITLE
Fix Qt ScrollBarPolicy usage for PyQt6

### DIFF
--- a/widgets/core/selectors.py
+++ b/widgets/core/selectors.py
@@ -175,8 +175,13 @@ class ProjectButtonRow(QtWidgets.QScrollArea):
 
     def __init__(self, parent=None, item_width: int = 100, item_height: int = 36):
         super().__init__(parent)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        # PyQt6 relocated ScrollBarPolicy enums under Qt.ScrollBarPolicy
+        self.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        self.setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
         self.setWidgetResizable(False)
         self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
 


### PR DESCRIPTION
## Summary
- fix ProjectButtonRow scrollbar enums for PyQt6

## Testing
- `python -m py_compile widgets/core/selectors.py`
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e231d52588328af888cbc49204127