### PR TITLE
Fix QSizePolicy enum usage for Qt6 compatibility

### DIFF
--- a/widgets/core/selectors.py
+++ b/widgets/core/selectors.py
@@ -188,7 +188,10 @@ class ProjectButtonRow(QtWidgets.QScrollArea):
         self._inner = HorizontalSelector(item_width=item_width, item_height=item_height)
         self._inner.changed.connect(self.changed.emit)
         # İç widget genişliği içeriğe göre ayarlansın
-        self._inner.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        # In Qt6, QSizePolicy enums moved under the Policy enum
+        self._inner.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
+        )
         self.setWidget(self._inner)
         self.setFixedHeight(item_height + 12)
 


### PR DESCRIPTION
## Summary
- Use `QSizePolicy.Policy.Fixed` when setting size policy in `ProjectButtonRow` to match Qt6 enum locations.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e35f2982883289c54f491da94021e