### PR TITLE
Improve project filtering and selection behavior

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -408,10 +408,18 @@ class PlannerPage(QtWidgets.QWidget):
 
     def _update_project_buttons(self):
         items: list[tuple[int, str]] = []
+        allowed: set[int] | None = None
+        if self._current_tag is not None:
+            allowed = {
+                int(t.get("project_id"))
+                for t in self._all_tasks
+                if t.get("project_id") and int(t.get("tag_id") or 0) == int(self._current_tag)
+            }
         for p in self._all_projects:
             try:
                 pid = int(p.get("id"))
-                items.append((pid, p.get("name", "")))
+                if allowed is None or pid in allowed:
+                    items.append((pid, p.get("name", "")))
             except Exception:
                 pass
         self.project_bar.setItems(items)


### PR DESCRIPTION
## Summary
- Allow deselecting tags and projects by clicking active buttons again
- Filter project list according to selected tag
- Hide project bar scroll and keep project/tag info when dragging tasks to calendar

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689e39dff21c8328a38422d81ae87413