### PR TITLE
Handle duplicate project names gracefully

### DIFF
--- a/services/local_db.py
+++ b/services/local_db.py
@@ -176,6 +176,11 @@ class LocalDB:
 
     # ---------------- PROJECTS ops ----------------
     def add_project_local(self, name: str) -> int:
+        existing = self._conn.execute(
+            "SELECT id FROM projects WHERE name=?", (name,)
+        ).fetchone()
+        if existing:
+            return int(existing["id"])
         cur = self._conn.execute("INSERT INTO projects(name) VALUES(?)", (name,))
         pid = int(cur.lastrowid)
         self._enqueue("projects", "insert", {"name": name})


### PR DESCRIPTION
## Summary
- avoid sqlite unique constraint errors when adding existing project

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3cc7fbbc83288e171d4a2cbca38c