### PR TITLE
Support tag ID when adding projects

### DIFF
--- a/services/supabase_api.py
+++ b/services/supabase_api.py
@@ -80,12 +80,14 @@ def fetch_projects() -> list[dict]:
     r.raise_for_status()
     return r.json()
 
-def upsert_project(name: str, project_id: int | None = None) -> dict:
+def upsert_project(name: str, project_id: int | None = None, tag_id: int | None = None) -> dict:
     _ensure()
     url = f"{SUPABASE_URL}/rest/v1/projects?on_conflict=id"
     payload = {"name": name}
     if project_id is not None:
         payload["id"] = int(project_id)
+    if tag_id is not None:
+        payload["tag_id"] = int(tag_id)
     r = requests.post(
         url,
         headers=_headers("return=representation,resolution=merge-duplicates"),

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -54,7 +54,7 @@ class SyncOrchestrator(QtCore.QObject):
                     pass
             for p in projects:
                 try:
-                    api.upsert_project(p.get("name", ""), p.get("id"))
+                    api.upsert_project(p.get("name", ""), p.get("id"), p.get("tag_id"))
                 except Exception:
                     pass
             for t in tasks:
@@ -79,10 +79,10 @@ class SyncOrchestrator(QtCore.QObject):
         self.tagsUpdated.emit(self.db.get_tags())
 
     # ---------- PROJECTS ----------
-    def add_project(self, name: str):
-        pid = self.db.add_project_local(name)
+    def add_project(self, name: str, tag_id: Optional[int] = None):
+        pid = self.db.add_project_local(name, tag_id)
         try:
-            api.upsert_project(name, pid)
+            api.upsert_project(name, pid, tag_id)
         except Exception:
             pass
         self.projectsUpdated.emit(self.db.get_projects())

--- a/services/sync_service.py
+++ b/services/sync_service.py
@@ -56,8 +56,8 @@ class SyncService(QtCore.QObject):
     def delete_tag(self, tag_id: int) -> bool:
         return api.delete_tag(tag_id)
 
-    def upsert_project(self, name: str, project_id: int | None = None) -> Dict[str, Any]:
-        return api.upsert_project(name, project_id)
+    def upsert_project(self, name: str, project_id: int | None = None, tag_id: int | None = None) -> Dict[str, Any]:
+        return api.upsert_project(name, project_id, tag_id)
 
     def delete_project(self, project_id: int) -> bool:
         return api.delete_project(project_id)


### PR DESCRIPTION
## Summary
- allow projects to store a tag reference in local SQLite schema
- propagate tag_id through SyncOrchestrator and remote API when creating or syncing projects

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e452bc7b08328b2f080355c409364