### PR TITLE
Add recurring tasks with postponement

### DIFF
--- a/planner_schema_patch.sql
+++ b/planner_schema_patch.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS public.tasks (
   start_ts    timestamptz NULL,
   end_ts      timestamptz NULL,
   parent_id   integer NULL,
+  series_id   integer NULL,
   created_at  timestamptz NOT NULL DEFAULT now(),
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
@@ -39,6 +40,9 @@ ALTER TABLE IF EXISTS public.tasks
 
 ALTER TABLE IF EXISTS public.tasks
   ADD COLUMN IF NOT EXISTS project_id integer NULL;
+
+ALTER TABLE IF EXISTS public.tasks
+  ADD COLUMN IF NOT EXISTS series_id integer NULL;
 
 -- 2) Faydalı indeksler ve view (tasks tablosu mevcutsa)
 DO $$

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -95,13 +95,18 @@ class SyncOrchestrator(QtCore.QObject):
     def upsert_task(self, task_id: Optional[int], title: str, notes: str,
                     due_date_iso: Optional[str], start_iso: Optional[str]=None,
                     end_iso: Optional[str]=None, parent_id: Optional[int]=None,
+                    series_id: Optional[int]=None,
                     tag_id: Optional[int]=None, project_id: Optional[int]=None) -> int:
-        tid = self.db.upsert_task(task_id, title, notes, due_date_iso, start_iso=start_iso, end_iso=end_iso, parent_id=parent_id, tag_id=tag_id, project_id=project_id)
+        tid = self.db.upsert_task(task_id, title, notes, due_date_iso, start_iso=start_iso, end_iso=end_iso, parent_id=parent_id, series_id=series_id, tag_id=tag_id, project_id=project_id)
         self._emit_all_from_local()
         return tid
 
     def delete_task(self, task_id: int):
-        self.db.delete_task(task_id)
+        self.db.delete_future(task_id)
+        self._emit_all_from_local()
+
+    def skip_task(self, task_id: int):
+        self.db.skip_task(task_id)
         self._emit_all_from_local()
 
     def set_task_status(self, task_id: int, status: str):


### PR DESCRIPTION
## Summary
- support recurring tasks with series tracking and future-deletion
- add UI for Weekdays/Daily/Weekly/custom repeats and postponement button
- generate multiple occurrences from recurrence rules

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e5136fb808328a66b07c9159ccf4d