### PR TITLE
feat: modernize task dialog layout

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -474,6 +474,12 @@ class PlannerPage(QtWidgets.QWidget):
             tasks = db.get_tasks() if db else []
         except Exception:
             tasks = []
+        child_rows = [
+            (int(ct["id"]), ct.get("title", ""))
+            for ct in tasks
+            if int(ct.get("parent_id") or 0) == int(task_id)
+        ]
+        m.children = child_rows
         opts = self._build_parent_options(tasks, m.tag_id, m.project_id, exclude_id=task_id)
         tag_opts = [(int(tg["id"]), tg.get("name", "")) for tg in self._all_tags]
         proj_opts = [


### PR DESCRIPTION
## Summary
- redesign task dialog into two-column layout with linked tasks list
- show tag, project and parent selectors with scheduling controls on the right
- load and preserve child tasks when editing

## Testing
- `python -m py_compile widgets/dialogs/event_task_dialog.py pages/planner_page.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fbc700328832889cce97c3bb55bb0