### PR TITLE
Implement splitter layout and advanced event dialog features

### DIFF
--- a/services/local_db.py
+++ b/services/local_db.py
@@ -155,6 +155,13 @@ class LocalDB:
         r = self._conn.execute("SELECT * FROM tasks WHERE id=?", (int(task_id),)).fetchone()
         return dict(r) if r else None
 
+    def get_linked_tasks(self, task_id: int) -> List[Dict[str, Any]]:
+        rs = self._conn.execute(
+            "SELECT id, title, due_date as due FROM tasks WHERE parent_id=?",
+            (int(task_id),),
+        ).fetchall()
+        return [dict(r) for r in rs]
+
     def get_events(self) -> List[Dict[str, Any]]:
         rs = self._conn.execute("""
             SELECT *, id as task_id FROM tasks

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -130,6 +130,12 @@ class SyncOrchestrator(QtCore.QObject):
         except Exception:
             pass
 
+    def get_task_by_id(self, task_id: int):
+        return self.db.get_task_by_id(task_id)
+
+    def get_linked_tasks(self, task_id: int):
+        return self.db.get_linked_tasks(task_id)
+
     # ---------- helpers ----------
     def _emit_all_from_local(self):
         self.tasksUpdated.emit(self.db.get_tasks())


### PR DESCRIPTION
## Summary
- Use a QSplitter to present planner columns with equal resizing
- Make linked tasks clickable and add a custom RFC5545 recurrence editor with postpone support
- Expose helper methods to fetch linked tasks and tasks by id

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc12bfbf08328b022ca1ec00dbd69