### PR TITLE
Fix PlannerPage navigation icon access

### DIFF
--- a/windows/main_window.py
+++ b/windows/main_window.py
@@ -37,7 +37,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # PlannerPage'i ÖNCE OLUŞTUR → sonra takvim buton ikonlarını ata
         self.page_planner = PlannerPage()
         # >>> Aylık takvim ileri/geri PNG ikonlarını burada veriyoruz
-        self.page_planner.left.setMonthNavIcons(
+        # Left panel holds the month navigation buttons; expose via
+        # ``left_panel_widget`` in ``PlannerPage``.
+        self.page_planner.left_panel_widget.setMonthNavIcons(
             "assets/icons/chev_left.png",   # senin sol yön PNG'in
             "assets/icons/chev_right.png",  # senin sağ yön PNG'in
             icon_px=18                      # buton üzerindeki ikon boyutu


### PR DESCRIPTION
## Summary
- use `left_panel_widget` instead of removed `left` attribute when applying month navigation icons in the planner page

## Testing
- `python -m py_compile windows/main_window.py`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt6 import QtWidgets
from windows.main_window import MainWindow
app = QtWidgets.QApplication([])
win = MainWindow()
print('window init ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689fc6294c74832884f0544f06278aea