### PR TITLE
Improve kanban rendering and calendar creation flows

### DIFF
--- a/widgets/dialogs/event_task_dialog.py
+++ b/widgets/dialogs/event_task_dialog.py
@@ -9,6 +9,7 @@ except Exception:
     rrulestr = None
 
 ISO_WEEKDAYS = ["MO","TU","WE","TH","FR","SA","SU"]
+DEFAULT_RRULE_COUNT = 24  # sonsuz seri yerine makul varsayılan
 
 @dataclass
 class ItemModel:
@@ -141,6 +142,8 @@ class RecurEditor(QtWidgets.QGroupBox):
             parts.append("UNTIL=" + dt_utc.strftime("%Y%m%dT%H%M%SZ"))
         elif self.endAfter.isChecked():
             parts.append(f"COUNT={self.countSpin.value()}")
+        elif self.endNever.isChecked() and self.freq.currentText() in ("Daily", "Weekly"):
+            parts.append(f"COUNT={DEFAULT_RRULE_COUNT}")
 
         return "RRULE:" + ";".join(parts)
 


### PR DESCRIPTION
## Summary
- Render Kanban cards with equal-width columns and `TAG>PROJECT>PARENT` metadata
- Enable quick event creation from week-view clicks and handle empty slots
- Add default RRULE count and safer recurrence expansion

## Testing
- `python -m py_compile kanban/board_lanes.py widgets/calendar/week_view_editable.py pages/planner_page.py widgets/dialogs/event_task_dialog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fe09f95748328a78930e971f7072e