### PR TITLE
Improve kanban interactions and weekly metadata

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -230,6 +230,7 @@ class PlannerPage(QtWidgets.QWidget):
         self.project_bar.changed.connect(self.on_project_changed)
         r_l.addWidget(self.project_bar)
         r_l.addWidget(self.kanban, 1)
+        self.kanban.newTaskRequested.connect(lambda: self._open_new_task_dialog(self._anchor_date, QtCore.QTime(0,0), QtCore.QTime(0,0), False))
 
         proj_row = QtWidgets.QHBoxLayout(); proj_row.setSpacing(8)
         self.btn_add_project = QtWidgets.QPushButton("+ New Project")
@@ -250,27 +251,12 @@ class PlannerPage(QtWidgets.QWidget):
         r_l.addLayout(proj_row)
         h.addWidget(right)
 
-        # QSplitter setup
-        self.splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        self.splitter.setHandleWidth(8)
-        self.splitter.setChildrenCollapsible(False)
-        self.splitter.addWidget(self.left_panel_widget)
-        self.splitter.addWidget(self.calendar_container)
-        self.splitter.setStretchFactor(0, 1)
-        self.splitter.setStretchFactor(1, 1)
-        self.splitter.setSizes([500, 500])
-        self.splitter.setStyleSheet(
-            """
-QSplitter::handle {
-  background: #2d2d2d;
-}
-QWidget#Card {
-  border: 1px solid #333; border-radius: 12px; background: #212121;
-}
-"""
-        )
-
-        root.addWidget(self.splitter, 1)
+        main_row = QtWidgets.QHBoxLayout()
+        main_row.setContentsMargins(0, 0, 0, 0)
+        main_row.setSpacing(8)
+        main_row.addWidget(self.left_panel_widget)
+        main_row.addWidget(self.calendar_container, 1)
+        root.addLayout(main_row, 1)
 
         # Başlangıç
         if hasattr(self.week, "setAnchorDate"):

--- a/widgets/calendar/week_view_editable.py
+++ b/widgets/calendar/week_view_editable.py
@@ -13,6 +13,7 @@ class EventBlock:
     end: datetime
     title: str = ""
     id: int | None = None
+    meta: str = ""
     # opsiyonel not/rrule alanları UI tarafında taşınabilir
     notes: str | None = None
     rrule: str | None = None
@@ -93,12 +94,18 @@ class CalendarWeekView(QtWidgets.QWidget):
                 end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
             except Exception:
                 continue
+            meta_parts = []
+            if ev.get("tag_name"): meta_parts.append(ev["tag_name"])
+            if ev.get("project_name"): meta_parts.append(ev["project_name"])
+            if ev.get("parent_title"): meta_parts.append(ev["parent_title"])
+            meta = ">".join(meta_parts)
             block = EventBlock(
                 task_id=int(ev.get("task_id") or ev.get("taskId") or 0),
                 start=start,
                 end=end,
                 title=ev.get("title", ""),
                 id=int(ev["id"]) if ev.get("id") is not None else None,
+                meta=meta,
                 notes=ev.get("notes"),
                 rrule=ev.get("rrule"),
             )
@@ -303,3 +310,12 @@ class CalendarWeekView(QtWidgets.QWidget):
                 QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignLeft,
                 title,
             )
+            meta = getattr(self._events[idx], "meta", "")
+            if meta:
+                p.setPen(QtGui.QPen(QtGui.QColor(COLOR_TEXT_MUTED)))
+                p.drawText(
+                    r.adjusted(6, 18, -6, 0),
+                    QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignLeft,
+                    meta,
+                )
+                p.setPen(QtGui.QPen(QtGui.QColor(COLOR_TEXT)))


### PR DESCRIPTION
## Summary
- allow dragging tasks across kanban lanes and add double-click to create tasks
- show only dates on kanban cards and display tag>project>parent under weekly event titles
- remove splitter handle between panels on planner page

## Testing
- `python3 -m py_compile kanban/board_lanes.py widgets/calendar/week_view_editable.py pages/planner_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe514100083288ca7a9167cc19d33