### PR TITLE
Fix day view text rendering and refine weekly view colors

### DIFF
--- a/widgets/calendar/day_view.py
+++ b/widgets/calendar/day_view.py
@@ -306,12 +306,12 @@ class CalendarDayView(QtWidgets.QWidget):
             text_x = r.x() + 6
             text_y = r.y() + fm.ascent() + 2
             p.setPen(QtGui.QPen(QtGui.QColor(COLOR_TEXT)))
-            p.drawText(text_x, text_y, ev.title)
+            p.drawText(int(text_x), int(text_y), ev.title)
             if ev.meta:
                 text_y += fm.height()
                 p.setPen(QtGui.QPen(QtGui.QColor(COLOR_TEXT_MUTED)))
-                p.drawText(text_x, text_y, ev.meta)
+                p.drawText(int(text_x), int(text_y), ev.meta)
             if ev.due:
                 text_y += fm.height()
                 p.setPen(QtGui.QPen(QtGui.QColor(COLOR_TEXT)))
-                p.drawText(text_x, text_y, ev.due)
+                p.drawText(int(text_x), int(text_y), ev.due)


### PR DESCRIPTION
## Summary
- Cast text positions to integers in day view to satisfy QPainter.drawText
- Color weekly events secondary by default, highlight overlapping events with primary, and outline all with accent

## Testing
- `python -m py_compile widgets/calendar/day_view.py widgets/calendar/week_view.py widgets/calendar/week_view_editable.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff76ac01483289d7c08113eadbd08