### PR TITLE
Normalize event datetimes

### DIFF
--- a/widgets/calendar/week_view_editable.py
+++ b/widgets/calendar/week_view_editable.py
@@ -102,6 +102,10 @@ class CalendarWeekView(QtWidgets.QWidget):
                     continue
                 start = datetime.fromisoformat(str(start_raw).replace("Z", "+00:00"))
                 end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
+                if start.tzinfo is not None:
+                    start = start.astimezone().replace(tzinfo=None)
+                if end.tzinfo is not None:
+                    end = end.astimezone().replace(tzinfo=None)
             except Exception:
                 continue
             meta_parts = []


### PR DESCRIPTION
## Summary
- normalize event datetimes by removing timezone info so comparisons don't mix aware/naive datetimes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff9261a808328a3cb884275e05382