### PR TITLE
Integrate Pomodoro sessions with planner and task dialogs

### DIFF
--- a/pages/pomodoro_page.py
+++ b/pages/pomodoro_page.py
@@ -1,49 +1,529 @@
-from PyQt6 import QtCore, QtWidgets
-from theme.colors import COLOR_PRIMARY_BG, COLOR_SECONDARY_BG, COLOR_TEXT, COLOR_ACCENT
+"""
+pomodoro_page.py — Planner uyumlu Pomodoro (iki mod + not + görev seçici + ikon bar)
+"""
+
+from __future__ import annotations
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from datetime import datetime, timedelta
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+# Planner renkleri
+try:
+    from theme.colors import (
+        COLOR_PRIMARY_BG,
+        COLOR_SECONDARY_BG,
+        COLOR_TEXT,
+        COLOR_TEXT_MUTED,
+        COLOR_ACCENT,
+    )
+except Exception:  # pragma: no cover - fallback colors
+    COLOR_PRIMARY_BG = "#212121"
+    COLOR_SECONDARY_BG = "#2d2d2d"
+    COLOR_TEXT = "#EEEEEE"
+    COLOR_TEXT_MUTED = "#AEAEAE"
+    COLOR_ACCENT = "#15B4B9"
+
 
 class PomodoroPage(QtWidgets.QWidget):
-    def __init__(self, parent=None):
+    """
+    - Başlamadan önce: orta bölümde büyük editable süre (borderless QLineEdit görünümlü sayaç)
+    - Başladıktan sonra: büyük LABEL sayaç
+    - Sol: not alanı (sayfanın ~1/3’ü)
+    - Sağ: In Progress görev seçici (TAG > PROJECT > TASK listesi)
+    - Alt merkez: ikon barı (Başlat, Durdur, Sıfırla, Erken Bitir)
+    - Sinyaller:
+        started(task_id:int|None, plan_secs:int)
+        paused(task_id:int|None, elapsed_secs:int)
+        reset(task_id:int|None)
+        completed(task_id:int|None, actual_secs:int, plan_secs:int, note:str)
+    """
+
+    started = QtCore.pyqtSignal(object, int)
+    paused = QtCore.pyqtSignal(object, int)
+    reset = QtCore.pyqtSignal(object)
+    completed = QtCore.pyqtSignal(object, int, int, str)
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
-        self._remaining = 25 * 60
-        self._timer = QtCore.QTimer(self); self._timer.setInterval(1000); self._timer.timeout.connect(self._tick)
 
-        self.setStyleSheet(f"background:{COLOR_PRIMARY_BG}; color:{COLOR_TEXT};")
-        v = QtWidgets.QVBoxLayout(self); v.setContentsMargins(12,12,12,12); v.setSpacing(12)
+        # --- State ---
+        self._plan_secs: int = 25 * 60
+        self._remaining: int = self._plan_secs
+        self._running: bool = False
+        self._current_task_id: Optional[int] = None
+        self._elapsed_before_pause: int = 0
+        self._tick_start_mono_ms: int = 0
+        self._store: Any = None
+        self._task_fetcher: Optional[Callable[[], List[Dict[str, Any]]]] = None
 
-        title = QtWidgets.QLabel("Pomodoro"); title.setStyleSheet("font-size:20px; font-weight:600;")
-        v.addWidget(title)
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(1000)
+        self._timer.timeout.connect(self._on_tick)
 
-        card = QtWidgets.QFrame(); card.setStyleSheet(f"background:{COLOR_SECONDARY_BG}; border:1px solid #3a3a3a; border-radius:12px;")
-        c = QtWidgets.QVBoxLayout(card); c.setContentsMargins(16,16,16,16); c.setSpacing(12)
+        self._build_ui()
+        self._apply_styles()
+        self._sync_labels()
+        self._wire()
 
-        self.lbl = QtWidgets.QLabel(self._fmt()); self.lbl.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        self.lbl.setStyleSheet("font-size:36px; font-weight:600;")
-        c.addWidget(self.lbl)
+    # ------------------------------ Public API ---------------------------------
 
-        row = QtWidgets.QHBoxLayout()
-        self.btn_start = QtWidgets.QPushButton("Start"); self.btn_pause = QtWidgets.QPushButton("Pause"); self.btn_reset = QtWidgets.QPushButton("Reset")
-        for b in (self.btn_start, self.btn_pause, self.btn_reset):
-            b.setFixedHeight(36); b.setStyleSheet(f"background:{COLOR_ACCENT}; border-radius:10px;")
-        self.btn_start.clicked.connect(self._start); self.btn_pause.clicked.connect(self._pause); self.btn_reset.clicked.connect(self._reset)
-        row.addWidget(self.btn_start); row.addWidget(self.btn_pause); row.addWidget(self.btn_reset)
-        c.addLayout(row)
+    def set_store(
+        self,
+        store: Any,
+        fetcher_name_candidates: Tuple[str, ...] = (
+            "list_open_tasks",
+            "list_tasks",
+            "fetch_tasks",
+            "all_tasks",
+        ),
+    ):
+        self._store = store
+        self._task_fetcher = None
+        for name in fetcher_name_candidates:
+            if hasattr(store, name):
+                fn = getattr(store, name)
+                if callable(fn):
+                    def fetch():
+                        try:
+                            tasks = fn()
+                        except TypeError:
+                            tasks = fn(self)
+                        return self._normalize_tasks(tasks)
 
-        v.addWidget(card, 1)
+                    self._task_fetcher = fetch
+                    break
+        self.reload_tasks()
 
-    def _fmt(self):
-        m, s = divmod(self._remaining, 60)
-        return f"{m:02d}:{s:02d}"
+    def set_tasks(self, tasks: List[Dict[str, Any]]):
+        self._task_fetcher = lambda: self._normalize_tasks(tasks)
+        self.reload_tasks()
 
-    def _tick(self):
-        if self._remaining > 0:
-            self._remaining -= 1
-            self.lbl.setText(self._fmt())
+    def reload_tasks(self):
+        items = []
+        if self._task_fetcher:
+            try:
+                items = self._task_fetcher() or []
+            except Exception:
+                items = []
+        # Sadece "In Progress"
+        items = [
+            t
+            for t in items
+            if (t.get("status") or "").lower()
+            in ("in progress", "in_progress", "progress", "working", "doing")
+        ]
+        self._tasks_all = items
+        self._fill_tag_project_filters()
+
+    # ------------------------------ UI -----------------------------------------
+
+    def _build_ui(self):
+        self.setObjectName("PomodoroPage")
+        root = QtWidgets.QVBoxLayout(self)
+        root.setContentsMargins(12, 12, 12, 12)  # Planner başlık hizasıyla aynı
+        root.setSpacing(12)
+
+        # Title
+        self.lbl_title = QtWidgets.QLabel("Pomodoro")
+        self.lbl_title.setObjectName("title")
+        root.addWidget(self.lbl_title, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+
+        # Orta üçlü: Sol Not — Orta Sayaç — Sağ Görev Paneli
+        tri = QtWidgets.QHBoxLayout()
+        tri.setSpacing(12)
+        root.addLayout(tri, 1)
+
+        # Sol: Not alanı
+        left = QtWidgets.QFrame()
+        left.setObjectName("pane")
+        left.setMinimumWidth(260)
+        l_lo = QtWidgets.QVBoxLayout(left)
+        l_lo.setContentsMargins(12, 12, 12, 12)
+        l_lo.setSpacing(8)
+        l_lo.addWidget(QtWidgets.QLabel("Notlar (bu pomodoro’ya kaydedilecek):"))
+        self.txt_notes = QtWidgets.QTextEdit()
+        self.txt_notes.setPlaceholderText("Pomodoro notlarını buraya yaz…")
+        l_lo.addWidget(self.txt_notes, 1)
+        tri.addWidget(left, 1)
+
+        # Orta: Sayaç (iki mod için stacked)
+        center = QtWidgets.QFrame()
+        center.setObjectName("pane")
+        c_lo = QtWidgets.QVBoxLayout(center)
+        c_lo.setContentsMargins(12, 12, 12, 12)
+        c_lo.setSpacing(8)
+
+        self.stack_timer = QtWidgets.QStackedWidget()
+
+        # Pre-start: borderless editable süre (line edit – büyük yazı)
+        pre = QtWidgets.QWidget()
+        pre_lo = QtWidgets.QVBoxLayout(pre)
+        pre_lo.setContentsMargins(0, 0, 0, 0)
+        pre_lo.setSpacing(0)
+        self.edit_time = QtWidgets.QLineEdit()
+        self.edit_time.setObjectName("edit_time")
+        self.edit_time.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.edit_time.setPlaceholderText("25:00")
+        pre_lo.addStretch(1)
+        pre_lo.addWidget(self.edit_time)
+        pre_lo.addStretch(1)
+
+        # Running: büyük label
+        run = QtWidgets.QWidget()
+        run_lo = QtWidgets.QVBoxLayout(run)
+        run_lo.setContentsMargins(0, 0, 0, 0)
+        run_lo.setSpacing(0)
+        self.lbl_time = QtWidgets.QLabel("--:--")
+        self.lbl_time.setObjectName("time")
+        self.lbl_time.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        run_lo.addStretch(1)
+        run_lo.addWidget(self.lbl_time)
+        run_lo.addStretch(1)
+
+        self.stack_timer.addWidget(pre)  # index 0
+        self.stack_timer.addWidget(run)  # index 1
+
+        c_lo.addWidget(self.stack_timer, 1)
+        center.setLayout(c_lo)
+        tri.addWidget(center, 1)
+
+        # Sağ: In Progress görev seçici (TAG → PROJECT → TASK)
+        right = QtWidgets.QFrame()
+        right.setObjectName("pane")
+        r_lo = QtWidgets.QVBoxLayout(right)
+        r_lo.setContentsMargins(12, 12, 12, 12)
+        r_lo.setSpacing(8)
+
+        row_tag = QtWidgets.QHBoxLayout()
+        row_tag.addWidget(QtWidgets.QLabel("Tag:"))
+        self.cmb_tag = QtWidgets.QComboBox()
+        row_tag.addWidget(self.cmb_tag, 1)
+        r_lo.addLayout(row_tag)
+
+        row_proj = QtWidgets.QHBoxLayout()
+        row_proj.addWidget(QtWidgets.QLabel("Proje:"))
+        self.cmb_proj = QtWidgets.QComboBox()
+        row_proj.addWidget(self.cmb_proj, 1)
+        r_lo.addLayout(row_proj)
+
+        r_lo.addWidget(QtWidgets.QLabel("Görevler:"))
+        self.list_tasks = QtWidgets.QListWidget()
+        self.list_tasks.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        r_lo.addWidget(self.list_tasks, 1)
+
+        tri.addWidget(right, 1)
+
+        # Alt: ikon bar (merkez)
+        bar = QtWidgets.QHBoxLayout()
+        bar.setContentsMargins(0, 0, 0, 0)
+        bar.setSpacing(8)
+        root.addLayout(bar, 0)
+
+        bar.addStretch(1)
+        self.btn_start = QtWidgets.QToolButton()
+        self.btn_start.setIcon(
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        )
+        self.btn_start.setToolTip("Başlat")
+        self.btn_pause = QtWidgets.QToolButton()
+        self.btn_pause.setIcon(
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPause)
+        )
+        self.btn_pause.setToolTip("Durdur")
+        self.btn_reset = QtWidgets.QToolButton()
+        self.btn_reset.setIcon(
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserReload)
+        )
+        self.btn_reset.setToolTip("Sıfırla")
+        self.btn_finish = QtWidgets.QToolButton()
+        self.btn_finish.setIcon(
+            self.style().standardIcon(
+                QtWidgets.QStyle.StandardPixmap.SP_DialogApplyButton
+            )
+        )
+        self.btn_finish.setToolTip("Erken bitir / Tamamlandı")
+        for b in (self.btn_start, self.btn_pause, self.btn_reset, self.btn_finish):
+            b.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
+            b.setIconSize(QtCore.QSize(28, 28))
+        bar.addWidget(self.btn_start)
+        bar.addWidget(self.btn_pause)
+        bar.addWidget(self.btn_reset)
+        bar.addWidget(self.btn_finish)
+        bar.addStretch(1)
+
+    def _apply_styles(self):
+        self.setStyleSheet(
+            f"""
+            QWidget#PomodoroPage {{
+                background: {COLOR_PRIMARY_BG};
+                color: {COLOR_TEXT};
+            }}
+            QLabel#title {{
+                font-size: 20px;
+                font-weight: 600;
+                padding-left: 2px;  /* Planner başlık hizası */
+            }}
+            QFrame#pane {{
+                background: {COLOR_SECONDARY_BG};
+                border: 1px solid #3a3a3a;
+                border-radius: 14px;
+            }}
+            QLabel#time {{
+                font-size: 64px;
+                font-weight: 800;
+                padding: 8px 0 12px 0;
+            }}
+            QLineEdit#edit_time {{
+                font-size: 64px;
+                font-weight: 800;
+                padding: 8px 0 12px 0;
+                border: none;
+                background: transparent;
+                color: {COLOR_TEXT};
+                selection-background-color: {COLOR_ACCENT};
+            }}
+            QComboBox, QListWidget, QTextEdit {{
+                background: {COLOR_PRIMARY_BG};
+                border: 1px solid #3a3a3a;
+                border-radius: 10px;
+                color: {COLOR_TEXT};
+            }}
+            QToolButton {{
+                background: {COLOR_SECONDARY_BG};
+                border: 1px solid #3a3a3a;
+                border-radius: 10px;
+                padding: 8px;
+            }}
+            QToolButton:hover {{ border-color: #4a4a4a; }}
+        """
+        )
+
+    def _wire(self):
+        self.btn_start.clicked.connect(self._start)
+        self.btn_pause.clicked.connect(self._pause)
+        self.btn_reset.clicked.connect(self._reset)
+        self.btn_finish.clicked.connect(self._finish_early)
+
+        self.edit_time.editingFinished.connect(self._apply_edit_time)
+
+        self.cmb_tag.currentIndexChanged.connect(self._apply_filters)
+        self.cmb_proj.currentIndexChanged.connect(self._apply_filters)
+        self.list_tasks.itemSelectionChanged.connect(self._on_task_selected)
+
+    # ------------------------------ Tasks Sidebar -------------------------------
+
+    def _normalize_tasks(self, tasks: Any) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for t in tasks or []:
+            if isinstance(t, dict):
+                tid = t.get("id") or t.get("task_id")
+                title = t.get("title") or t.get("name") or f"Task {tid}"
+                tag = t.get("tag") or t.get("tag_name") or ""
+                proj = t.get("project") or t.get("project_name") or ""
+                parent = t.get("parent") or t.get("parent_title") or ""
+                status = t.get("status") or t.get("state") or ""
+            elif isinstance(t, (tuple, list)) and len(t) >= 2:
+                tid, title = t[0], t[1]
+                tag = proj = parent = status = ""
+            else:
+                continue
+            meta_parts = [p for p in (tag, proj, parent) if p]
+            meta = ">".join(meta_parts) if meta_parts else ""
+            out.append(
+                {
+                    "id": tid,
+                    "title": title,
+                    "tag": tag,
+                    "project": proj,
+                    "parent": parent,
+                    "meta": meta,
+                    "status": status,
+                }
+            )
+        return out
+
+    def _fill_tag_project_filters(self):
+        tags = sorted({t["tag"] for t in self._tasks_all if t.get("tag")})
+        self.cmb_tag.blockSignals(True)
+        self.cmb_tag.clear()
+        self.cmb_tag.addItem("Tümü", userData=None)
+        for tg in tags:
+            self.cmb_tag.addItem(tg, userData=tg)
+        self.cmb_tag.blockSignals(False)
+
+        self._apply_filters()
+
+    def _apply_filters(self):
+        sel_tag = self.cmb_tag.currentData()
+        filtered = [t for t in self._tasks_all if (sel_tag is None or t.get("tag") == sel_tag)]
+
+        projs = sorted({t["project"] for t in filtered if t.get("project")})
+        self.cmb_proj.blockSignals(True)
+        self.cmb_proj.clear()
+        self.cmb_proj.addItem("Tümü", userData=None)
+        for pr in projs:
+            self.cmb_proj.addItem(pr, userData=pr)
+        self.cmb_proj.blockSignals(False)
+
+        self._fill_task_list()
+
+    def _fill_task_list(self):
+        sel_tag = self.cmb_tag.currentData()
+        sel_proj = self.cmb_proj.currentData()
+
+        items = [
+            t
+            for t in self._tasks_all
+            if (sel_tag is None or t.get("tag") == sel_tag)
+            and (sel_proj is None or t.get("project") == sel_proj)
+        ]
+
+        self.list_tasks.clear()
+        for t in items:
+            txt = t["title"] if not t.get("meta") else f'{t["title"]} ({t["meta"]})'
+            it = QtWidgets.QListWidgetItem(txt)
+            it.setData(QtCore.Qt.ItemDataRole.UserRole, t["id"])
+            self.list_tasks.addItem(it)
+
+        # önceki seçimi muhafaza etmek istersen burada arayabilirsin.
+
+    def _on_task_selected(self):
+        it = self.list_tasks.currentItem()
+        self._current_task_id = (
+            it.data(QtCore.Qt.ItemDataRole.UserRole) if it else None
+        )
+
+    # ------------------------------ Timer Logic ---------------------------------
+
+    def _apply_edit_time(self):
+        text = (self.edit_time.text() or "").strip()
+        secs = self._parse_duration_text(text) if text else self._plan_secs
+        if secs <= 0:
+            secs = 60
+        self._plan_secs = secs
+        if not self._running:
+            self._remaining = secs
+            self._elapsed_before_pause = 0
+        self._sync_labels()
+
+    def _parse_duration_text(self, text: str) -> int:
+        # "25" (dk), "25:00", "1:30:00" (hh:mm:ss) destekler
+        parts = [p for p in text.replace(" ", "").split(":") if p != ""]
+        if not parts:
+            return 0
+        if len(parts) == 1:
+            m = int(parts[0])
+            return max(0, m) * 60
+        if len(parts) == 2:
+            m, s = int(parts[0]), int(parts[1])
+            return m * 60 + s
+        if len(parts) == 3:
+            h, m, s = int(parts[0]), int(parts[1]), int(parts[2])
+            return h * 3600 + m * 60 + s
+        return 0
+
+    def _sync_labels(self):
+        m, s = divmod(max(0, self._remaining), 60)
+        if self._running:
+            self.lbl_time.setText(f"{m:02d}:{s:02d}")
         else:
-            self._timer.stop()
+            # pre-start input'u da bu formata eşitle
+            self.edit_time.setText(f"{m:02d}:{s:02d}")
 
-    def _start(self): self._timer.start()
-    def _pause(self): self._timer.stop()
-    def _reset(self):
+    def _start(self):
+        if self._running:
+            return
+        # süreyi editörden güncelle
+        self._apply_edit_time()
+        self._running = True
+        self._tick_start_mono_ms = QtCore.QTime.currentTime().msecsSinceStartOfDay()
+        self._timer.start()
+        self.stack_timer.setCurrentIndex(1)  # Running görünüme geç
+        self.started.emit(self._current_task_id, self._plan_secs)
+
+    def _pause(self):
+        if not self._running:
+            return
         self._timer.stop()
-        self._remaining = 25 * 60
-        self.lbl.setText(self._fmt())
+        self._running = False
+        self._elapsed_before_pause = self._elapsed_total()
+        self.stack_timer.setCurrentIndex(0)  # Pre-start görünümüne dön (süre editlenebilir)
+        self.paused.emit(self._current_task_id, self._elapsed_before_pause)
+
+    def _reset(self):
+        was_running = self._running
+        if was_running:
+            self._timer.stop()
+        self._running = False
+        self._elapsed_before_pause = 0
+        self._remaining = self._plan_secs
+        self.stack_timer.setCurrentIndex(0)
+        self._sync_labels()
+        self.reset.emit(self._current_task_id)
+
+    def _finish_early(self):
+        """Erken bitir: planı tamamlamadan seansı sonlandır."""
+        actual = (
+            self._elapsed_total() if self._running else self._elapsed_before_pause
+        )
+        self._finish_and_log(actual_secs=max(1, actual))
+
+    def _elapsed_total(self) -> int:
+        if not self._running:
+            return self._elapsed_before_pause
+        now_ms = QtCore.QTime.currentTime().msecsSinceStartOfDay()
+        delta_ms = max(0, now_ms - self._tick_start_mono_ms)
+        return self._elapsed_before_pause + delta_ms // 1000
+
+    def _on_tick(self):
+        if not self._running:
+            return
+        self._remaining = max(0, self._remaining - 1)
+        self._sync_labels()
+        if self._remaining <= 0:
+            self._finish_and_log(actual_secs=self._plan_secs)
+
+    def _finish_and_log(self, actual_secs: int):
+        # Sayaç durumu
+        self._timer.stop()
+        self._running = False
+        self._elapsed_before_pause = 0
+        self._remaining = self._plan_secs
+        self.stack_timer.setCurrentIndex(0)
+        self._sync_labels()
+
+        note = (self.txt_notes.toPlainText() or "").strip()
+        self.completed.emit(
+            self._current_task_id,
+            int(actual_secs),
+            int(self._plan_secs),
+            note,
+        )
+
+        # DB’ye yaz (varsa store)
+        try:
+            if self._store and hasattr(self._store, "add_pomodoro_session"):
+                self._store.add_pomodoro_session(
+                    task_id=self._current_task_id,
+                    planned_secs=int(self._plan_secs),
+                    actual_secs=int(actual_secs),
+                    note=note,
+                )
+        except Exception:
+            pass
+
+        # Görsel bir feedback
+        try:
+            eff = QtWidgets.QGraphicsColorizeEffect(self)
+            eff.setColor(QtGui.QColor(COLOR_ACCENT))
+            self.setGraphicsEffect(eff)
+            QtCore.QTimer.singleShot(600, lambda: self.setGraphicsEffect(None))
+        except Exception:
+            pass
+
+        # Notu temizlemek istersen (yorum satırını kaldır)
+        # self.txt_notes.clear()
+

--- a/services/local_db.py
+++ b/services/local_db.py
@@ -13,6 +13,8 @@ class LocalDB:
         self._conn = sqlite3.connect(self.path)
         self._conn.row_factory = sqlite3.Row
         self._ensure_schema()
+        # Pomodoro session table migration
+        self.migrate_add_pomodoro_sessions()
 
     # ---------------- Schema ----------------
     def _ensure_schema(self):
@@ -54,6 +56,25 @@ class LocalDB:
             payload TEXT NOT NULL,
             created_at TEXT DEFAULT (datetime('now'))
         )""")
+        self._conn.commit()
+
+    def migrate_add_pomodoro_sessions(self):
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pomodoro_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id INTEGER NOT NULL,
+                started_at TEXT NOT NULL,
+                ended_at   TEXT NOT NULL,
+                planned_secs INTEGER NOT NULL,
+                actual_secs  INTEGER NOT NULL,
+                note TEXT DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+            );
+            """
+        )
         self._conn.commit()
 
     # ---------------- Queue helpers ----------------
@@ -250,3 +271,52 @@ class LocalDB:
                            (_now_iso(), int(event_id)))
         self._enqueue("events", "delete", {"id": int(event_id)})
         self._conn.commit()
+
+    # ---------------- Pomodoro sessions ----------------
+    def insert_pomodoro_session(
+        self,
+        task_id: int,
+        started_at_iso: str,
+        ended_at_iso: str,
+        planned_secs: int,
+        actual_secs: int,
+        note: str,
+    ) -> int:
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO pomodoro_sessions (task_id, started_at, ended_at, planned_secs, actual_secs, note)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (task_id, started_at_iso, ended_at_iso, planned_secs, actual_secs, note),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_pomodoro_sessions_for_task(self, task_id: int) -> list[dict]:
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            SELECT id, task_id, started_at, ended_at, planned_secs, actual_secs, note, created_at
+            FROM pomodoro_sessions
+            WHERE task_id = ?
+            ORDER BY datetime(ended_at) DESC
+            """,
+            (task_id,),
+        )
+        rows = cur.fetchall()
+        out = []
+        for r in rows:
+            out.append(
+                {
+                    "id": r[0],
+                    "task_id": r[1],
+                    "started_at": r[2],
+                    "ended_at": r[3],
+                    "planned_secs": r[4],
+                    "actual_secs": r[5],
+                    "note": r[6],
+                    "created_at": r[7],
+                }
+            )
+        return out

--- a/widgets/dialogs/event_task_dialog.py
+++ b/widgets/dialogs/event_task_dialog.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
+from datetime import datetime
+
 from PyQt6 import QtCore, QtWidgets
+
+from theme.colors import COLOR_PRIMARY_BG, COLOR_SECONDARY_BG, COLOR_TEXT
+
 
 @dataclass
 class ItemModel:
-    kind: str                 # "task" or "event"
+    kind: str  # "task" or "event"
     id: Optional[int] = None
     title: str = ""
     notes: str = ""
@@ -15,52 +20,70 @@ class ItemModel:
     rrule: str | None = None
     task_id: Optional[int] = None  # if event
 
+
 class EventTaskDialog(QtWidgets.QDialog):
-    saved = QtCore.pyqtSignal(object)    # ItemModel
+    saved = QtCore.pyqtSignal(object)  # ItemModel
     deleted = QtCore.pyqtSignal(object)  # ItemModel
 
     def __init__(self, model: ItemModel, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Edit")
         self.setModal(True)
-        self._model = model
-        self.setMinimumWidth(480)
+        self.model = model
+        self.setMinimumWidth(640)
 
-        main = QtWidgets.QVBoxLayout(self)
-        main.setContentsMargins(14,14,14,14); main.setSpacing(10)
+        main_hbox = QtWidgets.QHBoxLayout(self)
+        main_hbox.setContentsMargins(14, 14, 14, 14)
+        main_hbox.setSpacing(10)
+
+        left_col = QtWidgets.QVBoxLayout()
+        left_col.setSpacing(10)
+        main_hbox.addLayout(left_col, 2)
 
         # Title
-        self.edt_title = QtWidgets.QLineEdit(); self.edt_title.setPlaceholderText("Title")
-        main.addWidget(self.edt_title)
+        self.edt_title = QtWidgets.QLineEdit()
+        self.edt_title.setPlaceholderText("Title")
+        left_col.addWidget(self.edt_title)
 
         # Notes
-        self.edt_notes = QtWidgets.QPlainTextEdit(); self.edt_notes.setPlaceholderText("Notes…")
+        self.edt_notes = QtWidgets.QPlainTextEdit()
+        self.edt_notes.setPlaceholderText("Notes…")
         self.edt_notes.setFixedHeight(100)
-        main.addWidget(self.edt_notes)
+        left_col.addWidget(self.edt_notes)
 
         # Date + time row
-        row = QtWidgets.QHBoxLayout(); row.setSpacing(8)
+        row = QtWidgets.QHBoxLayout()
+        row.setSpacing(8)
         self.date_edit = QtWidgets.QDateEdit(calendarPopup=True)
         self.date_edit.setDisplayFormat("yyyy-MM-dd")
         self.chk_time = QtWidgets.QCheckBox("Has time (event)")
-        self.start_edit = QtWidgets.QTimeEdit(); self.end_edit = QtWidgets.QTimeEdit()
-        self.start_edit.setDisplayFormat("HH:mm"); self.end_edit.setDisplayFormat("HH:mm")
-        row.addWidget(QtWidgets.QLabel("Date")); row.addWidget(self.date_edit)
-        row.addSpacing(12); row.addWidget(self.chk_time)
-        row.addSpacing(12); row.addWidget(QtWidgets.QLabel("Start")); row.addWidget(self.start_edit)
-        row.addWidget(QtWidgets.QLabel("End")); row.addWidget(self.end_edit, 1)
-        main.addLayout(row)
+        self.start_edit = QtWidgets.QTimeEdit()
+        self.end_edit = QtWidgets.QTimeEdit()
+        self.start_edit.setDisplayFormat("HH:mm")
+        self.end_edit.setDisplayFormat("HH:mm")
+        row.addWidget(QtWidgets.QLabel("Date"))
+        row.addWidget(self.date_edit)
+        row.addSpacing(12)
+        row.addWidget(self.chk_time)
+        row.addSpacing(12)
+        row.addWidget(QtWidgets.QLabel("Start"))
+        row.addWidget(self.start_edit)
+        row.addWidget(QtWidgets.QLabel("End"))
+        row.addWidget(self.end_edit, 1)
+        left_col.addLayout(row)
 
         # Recurrence
-        rec_row = QtWidgets.QHBoxLayout(); rec_row.setSpacing(8)
+        rec_row = QtWidgets.QHBoxLayout()
+        rec_row.setSpacing(8)
         self.cmb_recur = QtWidgets.QComboBox()
         self.cmb_recur.addItems(["None", "Daily", "Weekly", "Monthly", "Custom (RRULE)"])
-        self.edt_rrule = QtWidgets.QLineEdit(); self.edt_rrule.setPlaceholderText("RRULE=FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE")
+        self.edt_rrule = QtWidgets.QLineEdit()
+        self.edt_rrule.setPlaceholderText("RRULE=FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE")
         self.edt_rrule.setEnabled(False)
         rec_row.addWidget(QtWidgets.QLabel("Repeat"))
         rec_row.addWidget(self.cmb_recur, 1)
         rec_row.addWidget(self.edt_rrule, 2)
-        main.addLayout(rec_row)
+        left_col.addLayout(rec_row)
 
         # Buttons
         btn_row = QtWidgets.QHBoxLayout()
@@ -68,8 +91,50 @@ class EventTaskDialog(QtWidgets.QDialog):
         self.btn_delete = QtWidgets.QPushButton("Delete")
         self.btn_cancel = QtWidgets.QPushButton("Cancel")
         self.btn_save = QtWidgets.QPushButton("Save")
-        btn_row.addWidget(self.btn_delete); btn_row.addWidget(self.btn_cancel); btn_row.addWidget(self.btn_save)
-        main.addLayout(btn_row)
+        btn_row.addWidget(self.btn_delete)
+        btn_row.addWidget(self.btn_cancel)
+        btn_row.addWidget(self.btn_save)
+        left_col.addLayout(btn_row)
+
+        # --- Right column: Pomodoro geçmişi ---
+        right_col = QtWidgets.QFrame()
+        right_col.setObjectName("pomopane")
+        rlo = QtWidgets.QVBoxLayout(right_col)
+        rlo.setContentsMargins(12, 12, 12, 12)
+        rlo.setSpacing(8)
+
+        lbl_hist = QtWidgets.QLabel("Pomodorolar")
+        lbl_hist.setStyleSheet("font-weight:600;")
+        rlo.addWidget(lbl_hist)
+
+        self.list_pomo = QtWidgets.QListWidget()
+        self.list_pomo.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        rlo.addWidget(self.list_pomo, 1)
+
+        lbl_note = QtWidgets.QLabel("Seçili pomodoro notu")
+        rlo.addWidget(lbl_note)
+        self.view_pomo_note = QtWidgets.QTextEdit()
+        self.view_pomo_note.setReadOnly(True)
+        rlo.addWidget(self.view_pomo_note, 1)
+
+        right_col.setStyleSheet(
+            f"""
+            QFrame#pomopane {{
+                background: {COLOR_SECONDARY_BG};
+                border: 1px solid #3a3a3a;
+                border-radius: 14px;
+                color: {COLOR_TEXT};
+            }}
+            QListWidget, QTextEdit {{
+                background: {COLOR_PRIMARY_BG};
+                border: 1px solid #3a3a3a;
+                border-radius: 10px;
+                color: {COLOR_TEXT};
+            }}
+            """
+        )
+
+        main_hbox.addWidget(right_col, 1)
 
         # Wire
         self.cmb_recur.currentIndexChanged.connect(self._on_recur_changed)
@@ -77,6 +142,7 @@ class EventTaskDialog(QtWidgets.QDialog):
         self.btn_delete.clicked.connect(self._on_delete)
         self.btn_cancel.clicked.connect(self.reject)
         self.btn_save.clicked.connect(self._on_save)
+        self.list_pomo.itemSelectionChanged.connect(self._on_pomo_selected)
 
         self._load_model(model)
 
@@ -84,7 +150,8 @@ class EventTaskDialog(QtWidgets.QDialog):
         self.edt_rrule.setEnabled(self.cmb_recur.currentText() == "Custom (RRULE)")
 
     def _on_has_time_toggled(self, checked: bool):
-        self.start_edit.setEnabled(checked); self.end_edit.setEnabled(checked)
+        self.start_edit.setEnabled(checked)
+        self.end_edit.setEnabled(checked)
 
     def _load_model(self, m: ItemModel):
         self.edt_title.setText(m.title or "")
@@ -93,8 +160,10 @@ class EventTaskDialog(QtWidgets.QDialog):
         self.date_edit.setDate(qd)
         has_time = (m.start is not None and m.end is not None) or (m.kind == "event")
         self.chk_time.setChecked(has_time)
-        if m.start: self.start_edit.setTime(m.start)
-        if m.end: self.end_edit.setTime(m.end)
+        if m.start:
+            self.start_edit.setTime(m.start)
+        if m.end:
+            self.end_edit.setTime(m.end)
         if m.rrule:
             self.cmb_recur.setCurrentText("Custom (RRULE)")
             self.edt_rrule.setText(m.rrule)
@@ -103,11 +172,11 @@ class EventTaskDialog(QtWidgets.QDialog):
             self.cmb_recur.setCurrentText("None")
 
     def _on_delete(self):
-        self.deleted.emit(self._model)
+        self.deleted.emit(self.model)
         self.accept()
 
     def _on_save(self):
-        m = ItemModel(kind=self._model.kind, id=self._model.id, task_id=self._model.task_id)
+        m = ItemModel(kind=self.model.kind, id=self.model.id, task_id=self.model.task_id)
         m.title = self.edt_title.text().strip()
         m.notes = self.edt_notes.toPlainText().strip()
         m.date = self.date_edit.date()
@@ -115,7 +184,8 @@ class EventTaskDialog(QtWidgets.QDialog):
             m.start = self.start_edit.time()
             m.end = self.end_edit.time()
         else:
-            m.start = None; m.end = None
+            m.start = None
+            m.end = None
         sel = self.cmb_recur.currentText()
         if sel == "None":
             m.rrule = None
@@ -129,3 +199,34 @@ class EventTaskDialog(QtWidgets.QDialog):
             m.rrule = self.edt_rrule.text().strip() or None
         self.saved.emit(m)
         self.accept()
+
+    # ---------- Pomodoro history ----------
+    def _load_pomodoro_history(self, task_id: int):
+        self.list_pomo.clear()
+        try:
+            sessions = self.store.get_pomodoro_sessions(task_id)  # type: ignore[attr-defined]
+        except Exception:
+            sessions = []
+
+        for s in sessions:
+            try:
+                ended = datetime.fromisoformat(s["ended_at"])
+            except Exception:
+                ended = None
+            dur_m = int(max(1, s["actual_secs"])) // 60
+            plan_m = int(max(1, s["planned_secs"])) // 60
+            title = f"{ended.strftime('%d %b %H:%M') if ended else s['ended_at']} — {dur_m}m (plan:{plan_m}m)"
+            it = QtWidgets.QListWidgetItem(title)
+            it.setData(QtCore.Qt.ItemDataRole.UserRole, s)
+            self.list_pomo.addItem(it)
+
+    def showEvent(self, ev):  # type: ignore[override]
+        super().showEvent(ev)
+        if getattr(self, "model", None) and getattr(self.model, "id", None):
+            self._load_pomodoro_history(self.model.id)  # type: ignore[arg-type]
+
+    def _on_pomo_selected(self):
+        it = self.list_pomo.currentItem()
+        s = it.data(QtCore.Qt.ItemDataRole.UserRole) if it else None
+        self.view_pomo_note.setPlainText((s or {}).get("note", ""))
+

--- a/windows/main_window.py
+++ b/windows/main_window.py
@@ -6,7 +6,6 @@ from pages.planner_page import PlannerPage
 from pages.health_activity_page import HealthActivityPage
 from pages.performance_page import PerformancePage
 from pages.journal_page import JournalPage
-from pages.pomodoro_page import PomodoroPage
 
 from theme.colors import COLOR_PRIMARY_BG
 from utils.icons import make_app_icon_png
@@ -47,7 +46,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.page_health = HealthActivityPage()
         self.page_perf   = PerformancePage()
         self.page_journal= JournalPage()
-        self.page_pomo   = PomodoroPage()
+        self.page_pomo   = self.page_planner.pomo
 
         # Stack'e ekle
         self.pages = {}


### PR DESCRIPTION
## Summary
- Revamp Pomodoro page with notes, task filtering, dual-mode timer, and session logging
- Store Pomodoro sessions in SQLite and expose add/list APIs through SyncOrchestrator
- Show Pomodoro history on task dialog and refresh when sessions complete

## Testing
- `python -m py_compile pages/pomodoro_page.py services/local_db.py services/sync_orchestrator.py widgets/dialogs/event_task_dialog.py pages/planner_page.py windows/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68a13172e1988328a607d9bbc505e3a0