### PR TITLE
Add Pomodoro sessions tracking

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -17,6 +17,7 @@ from theme.colors import (
 )
 from services.sync_orchestrator import SyncOrchestrator
 from widgets.core.selectors import ProjectButtonRow
+from pages.pomodoro_page import PomodoroPage
 
 # Diyalog (tek ekran – task/event)
 try:
@@ -293,6 +294,11 @@ class PlannerPage(QtWidgets.QWidget):
         if hasattr(self.left_panel_widget, "attachStore"):
             self.left_panel_widget.attachStore(self.store)
         self.store.bootstrap()
+
+        self.pomo = PomodoroPage()
+        self.pomo.set_store(self.store)
+        self.pomo.completed.connect(self._on_pomo_completed)
+
         if hasattr(self.kanban, "statusChanged"):
             self.kanban.statusChanged.connect(self.store.set_task_status)
         if hasattr(self.kanban, "taskReparented"):
@@ -300,6 +306,23 @@ class PlannerPage(QtWidgets.QWidget):
 
     def _on_refresh_clicked(self):
         self.store.refresh()
+
+    def _on_pomo_completed(self, task_id, actual_secs, plan_secs, note):
+        # DB ekleme zaten PomodoroPage içinde store.add_pomodoro_session ile deneniyor.
+        # Burada istersen küçük bir “task activity” etiketi veya status güncellemesi yap.
+        if task_id:
+            try:
+                # Örn: toplam odak süresi alanın varsa burada artırabilirsin
+                pass
+            except Exception:
+                pass
+        # UI refresh: bir yerde açık diyalog varsa yenile
+        try:
+            if hasattr(self, "eventDialog") and self.eventDialog and self.eventDialog.isVisible():
+                if getattr(self.eventDialog._model, "id", None) == task_id:
+                    self.eventDialog._load_pomodoro_history(task_id)
+        except Exception:
+            pass
 
     def _on_add_project_clicked(self):
         # Tag seçili değilse proje eklenemez

--- a/pages/pomodoro_page.py
+++ b/pages/pomodoro_page.py
@@ -1,15 +1,15 @@
-# pomodoro_page.py  — TAM DOSYA (drop-in)
+# pomodoro_page.py — Planner uyumlu Pomodoro (iki mod + not + görev seçici + ikon bar)
 
 from __future__ import annotations
-
-from PyQt6 import QtCore, QtWidgets, QtGui
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from datetime import datetime, timedelta
 
-# Colors (align with Planner)
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+# Planner renkleri
 try:
     from theme.colors import COLOR_PRIMARY_BG, COLOR_SECONDARY_BG, COLOR_TEXT, COLOR_TEXT_MUTED, COLOR_ACCENT
 except Exception:
-    # Safe fallbacks
     COLOR_PRIMARY_BG   = "#212121"
     COLOR_SECONDARY_BG = "#2d2d2d"
     COLOR_TEXT         = "#EEEEEE"
@@ -19,17 +19,21 @@ except Exception:
 
 class PomodoroPage(QtWidgets.QWidget):
     """
-    Planner-benzeri Pomodoro sayfası:
-    - Süre ayarlanabilir (dakika)
-    - Task seçilip o task için Pomodoro başlatılabilir
-    - Başlat / Durdur / Sıfırla
-    - Planner Page stiliyle uyumlu kart tasarımı
-    - Sinyaller: started(task_id, secs), paused(task_id, elapsed), reset(task_id), completed(task_id)
+    - Başlamadan önce: orta bölümde büyük editable süre (borderless QLineEdit görünümlü sayaç)
+    - Başladıktan sonra: büyük LABEL sayaç
+    - Sol: not alanı (sayfanın ~1/3’ü)
+    - Sağ: In Progress görev seçici (TAG > PROJECT > TASK listesi)
+    - Alt merkez: ikon barı (Başlat, Durdur, Sıfırla, Erken Bitir)
+    - Sinyaller:
+        started(task_id:int|None, plan_secs:int)
+        paused(task_id:int|None, elapsed_secs:int)
+        reset(task_id:int|None)
+        completed(task_id:int|None, actual_secs:int, plan_secs:int, note:str)
     """
-    started   = QtCore.pyqtSignal(object, int)   # task_id, plan_secs
-    paused    = QtCore.pyqtSignal(object, int)   # task_id, elapsed_secs
-    reset     = QtCore.pyqtSignal(object)        # task_id
-    completed = QtCore.pyqtSignal(object, int)   # task_id, plan_secs
+    started   = QtCore.pyqtSignal(object, int)
+    paused    = QtCore.pyqtSignal(object, int)
+    reset     = QtCore.pyqtSignal(object)
+    completed = QtCore.pyqtSignal(object, int, int, str)
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
@@ -39,27 +43,23 @@ class PomodoroPage(QtWidgets.QWidget):
         self._remaining: int = self._plan_secs
         self._running: bool = False
         self._current_task_id: Optional[int] = None
-        self._elapsed_before_pause: int = 0  # toplam geçen süre
+        self._elapsed_before_pause: int = 0
         self._tick_start_mono_ms: int = 0
+        self._store: Any = None
+        self._task_fetcher: Optional[Callable[[], List[Dict[str, Any]]]] = None
 
         self._timer = QtCore.QTimer(self)
         self._timer.setInterval(1000)
         self._timer.timeout.connect(self._on_tick)
 
-        # optional store/callback for tasks
-        self._store: Any = None
-        self._task_fetcher: Optional[Callable[[], List[Dict[str, Any]]]] = None
-        self._all_tasks: List[Dict[str, Any]] = []
-
         self._build_ui()
         self._apply_styles()
         self._sync_labels()
-        self._update_ui_state()
+        self._wire()
 
     # ------------------------------ Public API ---------------------------------
 
     def set_store(self, store: Any, fetcher_name_candidates: Tuple[str, ...] = ("list_open_tasks", "list_tasks", "fetch_tasks", "all_tasks")):
-        """Store enjekte et; bilinen isimlerden birini deneyerek task listesi çek."""
         self._store = store
         self._task_fetcher = None
         for name in fetcher_name_candidates:
@@ -70,118 +70,127 @@ class PomodoroPage(QtWidgets.QWidget):
                         try:
                             tasks = fn()
                         except TypeError:
-                            tasks = fn(self)  # bazı implementasyonlar self istiyor olabilir
+                            tasks = fn(self)
                         return self._normalize_tasks(tasks)
                     self._task_fetcher = fetch
                     break
         self.reload_tasks()
 
     def set_tasks(self, tasks: List[Dict[str, Any]]):
-        """Harici listeden taskları yüklemek için alternatif API."""
         self._task_fetcher = lambda: self._normalize_tasks(tasks)
         self.reload_tasks()
 
     def reload_tasks(self):
-        items: List[Dict[str, Any]] = []
+        items = []
         if self._task_fetcher:
             try:
                 items = self._task_fetcher() or []
             except Exception:
                 items = []
-        items = [t for t in items if str(t.get("status", "")).lower() in {"in progress", "doing"}]
-        self._all_tasks = items
-        self._fill_tag_project()
-        self._apply_filters()
+        # Sadece "In Progress"
+        items = [t for t in items if (t.get("status") or "").lower() in ("in progress","in_progress","progress","working","doing")]
+        self._tasks_all = items
+        self._fill_tag_project_filters()
 
-    # ------------------------------ UI Build -----------------------------------
+    # ------------------------------ UI -----------------------------------------
 
     def _build_ui(self):
         self.setObjectName("PomodoroPage")
-        self.setAutoFillBackground(True)
+        root = QtWidgets.QVBoxLayout(self)
+        root.setContentsMargins(12, 12, 12, 12)  # Planner başlık hizasıyla aynı
+        root.setSpacing(12)
 
-        outer = QtWidgets.QHBoxLayout(self)
-        outer.setContentsMargins(12, 12, 12, 12)
-        outer.setSpacing(12)
+        # Title
+        self.lbl_title = QtWidgets.QLabel("Pomodoro")
+        self.lbl_title.setObjectName("title")
+        root.addWidget(self.lbl_title, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
 
-        # Left note area
-        self.note_edit = QtWidgets.QTextEdit()
-        self.note_edit.setObjectName("note")
-        self.note_edit.setPlaceholderText("Not...")
-        outer.addWidget(self.note_edit, 1)
+        # Orta üçlü: Sol Not — Orta Sayaç — Sağ Görev Paneli
+        tri = QtWidgets.QHBoxLayout()
+        tri.setSpacing(12)
+        root.addLayout(tri, 1)
 
-        # Center timer card
-        center_wrap = QtWidgets.QVBoxLayout()
-        outer.addLayout(center_wrap, 1)
+        # Sol: Not alanı
+        left = QtWidgets.QFrame()
+        left.setObjectName("pane")
+        left.setMinimumWidth(260)
+        l_lo = QtWidgets.QVBoxLayout(left); l_lo.setContentsMargins(12,12,12,12); l_lo.setSpacing(8)
+        l_lo.addWidget(QtWidgets.QLabel("Notlar (bu pomodoro’ya kaydedilecek):"))
+        self.txt_notes = QtWidgets.QTextEdit()
+        self.txt_notes.setPlaceholderText("Pomodoro notlarını buraya yaz…")
+        l_lo.addWidget(self.txt_notes, 1)
+        tri.addWidget(left, 1)
 
-        header = QtWidgets.QHBoxLayout()
-        lbl_title = QtWidgets.QLabel("Pomodoro")
-        lbl_title.setObjectName("title")
-        header.addWidget(lbl_title, 1)
-        center_wrap.addLayout(header)
+        # Orta: Sayaç (iki mod için stacked)
+        center = QtWidgets.QFrame()
+        center.setObjectName("pane")
+        c_lo = QtWidgets.QVBoxLayout(center); c_lo.setContentsMargins(12,12,12,12); c_lo.setSpacing(8)
 
-        card = QtWidgets.QFrame()
-        card.setObjectName("card")
-        center_wrap.addWidget(card, 1)
+        self.stack_timer = QtWidgets.QStackedWidget()
 
-        c = QtWidgets.QVBoxLayout(card)
-        c.setContentsMargins(16, 16, 16, 16)
-        c.setSpacing(12)
-
-        self.edit_time = QtWidgets.QLineEdit("25:00")
-        self.edit_time.setObjectName("timeEdit")
+        # Pre-start: borderless editable süre (line edit – büyük yazı)
+        pre = QtWidgets.QWidget()
+        pre_lo = QtWidgets.QVBoxLayout(pre); pre_lo.setContentsMargins(0,0,0,0); pre_lo.setSpacing(0)
+        self.edit_time = QtWidgets.QLineEdit()
+        self.edit_time.setObjectName("edit_time")
         self.edit_time.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        self.lbl_time = QtWidgets.QLabel("25:00")
-        self.lbl_time.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.edit_time.setPlaceholderText("25:00")
+        pre_lo.addStretch(1); pre_lo.addWidget(self.edit_time); pre_lo.addStretch(1)
+
+        # Running: büyük label
+        run = QtWidgets.QWidget()
+        run_lo = QtWidgets.QVBoxLayout(run); run_lo.setContentsMargins(0,0,0,0); run_lo.setSpacing(0)
+        self.lbl_time = QtWidgets.QLabel("--:--")
         self.lbl_time.setObjectName("time")
-        self.time_stack = QtWidgets.QStackedLayout()
-        self.time_stack.addWidget(self.edit_time)
-        self.time_stack.addWidget(self.lbl_time)
-        c.addLayout(self.time_stack)
+        self.lbl_time.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        run_lo.addStretch(1); run_lo.addWidget(self.lbl_time); run_lo.addStretch(1)
 
-        row_ctrl = QtWidgets.QHBoxLayout()
-        row_ctrl.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        self.btn_start = QtWidgets.QToolButton()
-        self.btn_start.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay))
-        self.btn_pause = QtWidgets.QToolButton()
-        self.btn_pause.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPause))
-        self.btn_reset = QtWidgets.QToolButton()
-        self.btn_reset.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserReload))
-        self.btn_complete = QtWidgets.QToolButton()
-        self.btn_complete.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogApplyButton))
-        for b in (self.btn_start, self.btn_pause, self.btn_reset, self.btn_complete):
-            b.setIconSize(QtCore.QSize(32, 32))
-            b.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
-        row_ctrl.addWidget(self.btn_start)
-        row_ctrl.addWidget(self.btn_pause)
-        row_ctrl.addWidget(self.btn_reset)
-        row_ctrl.addWidget(self.btn_complete)
-        c.addLayout(row_ctrl)
+        self.stack_timer.addWidget(pre)   # index 0
+        self.stack_timer.addWidget(run)   # index 1
 
-        # Right task selection
-        right_wrap = QtWidgets.QVBoxLayout()
-        outer.addLayout(right_wrap, 1)
-        right_wrap.addWidget(QtWidgets.QLabel("Tag:"))
+        c_lo.addWidget(self.stack_timer, 1)
+        center.setLayout(c_lo)
+        tri.addWidget(center, 1)
+
+        # Sağ: In Progress görev seçici (TAG → PROJECT → TASK)
+        right = QtWidgets.QFrame()
+        right.setObjectName("pane")
+        r_lo = QtWidgets.QVBoxLayout(right); r_lo.setContentsMargins(12,12,12,12); r_lo.setSpacing(8)
+
+        row_tag = QtWidgets.QHBoxLayout()
+        row_tag.addWidget(QtWidgets.QLabel("Tag:"))
         self.cmb_tag = QtWidgets.QComboBox()
-        right_wrap.addWidget(self.cmb_tag)
-        right_wrap.addWidget(QtWidgets.QLabel("Proje:"))
-        self.cmb_project = QtWidgets.QComboBox()
-        right_wrap.addWidget(self.cmb_project)
-        self.lst_tasks = QtWidgets.QListWidget()
-        right_wrap.addWidget(self.lst_tasks, 1)
-        self.btn_refresh = QtWidgets.QToolButton()
-        self.btn_refresh.setText("↻")
-        self.btn_refresh.setToolTip("Görev listesini yenile")
-        right_wrap.addWidget(self.btn_refresh)
+        row_tag.addWidget(self.cmb_tag, 1)
+        r_lo.addLayout(row_tag)
 
-        self.btn_refresh.clicked.connect(self.reload_tasks)
-        self.edit_time.editingFinished.connect(self._apply_edit_time)
-        self.btn_start.clicked.connect(self._start)
-        self.btn_pause.clicked.connect(self._pause)
-        self.btn_reset.clicked.connect(self._reset)
-        self.btn_complete.clicked.connect(self._complete_now)
-        self.lst_tasks.itemSelectionChanged.connect(self._on_task_changed)
-        self.cmb_tag.currentIndexChanged.connect(self._apply_filters)
-        self.cmb_project.currentIndexChanged.connect(self._apply_filters)
+        row_proj = QtWidgets.QHBoxLayout()
+        row_proj.addWidget(QtWidgets.QLabel("Proje:"))
+        self.cmb_proj = QtWidgets.QComboBox()
+        row_proj.addWidget(self.cmb_proj, 1)
+        r_lo.addLayout(row_proj)
+
+        r_lo.addWidget(QtWidgets.QLabel("Görevler:"))
+        self.list_tasks = QtWidgets.QListWidget()
+        self.list_tasks.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        r_lo.addWidget(self.list_tasks, 1)
+
+        tri.addWidget(right, 1)
+
+        # Alt: ikon bar (merkez)
+        bar = QtWidgets.QHBoxLayout()
+        bar.setContentsMargins(0,0,0,0); bar.setSpacing(8)
+        root.addLayout(bar, 0)
+
+        bar.addStretch(1)
+        self.btn_start = QtWidgets.QToolButton(); self.btn_start.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)); self.btn_start.setToolTip("Başlat")
+        self.btn_pause = QtWidgets.QToolButton(); self.btn_pause.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPause)); self.btn_pause.setToolTip("Durdur")
+        self.btn_reset = QtWidgets.QToolButton(); self.btn_reset.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserReload)); self.btn_reset.setToolTip("Sıfırla")
+        self.btn_finish= QtWidgets.QToolButton(); self.btn_finish.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogApplyButton)); self.btn_finish.setToolTip("Erken bitir / Tamamlandı")
+        for b in (self.btn_start, self.btn_pause, self.btn_reset, self.btn_finish):
+            b.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
+            b.setIconSize(QtCore.QSize(28,28))
+        bar.addWidget(self.btn_start); bar.addWidget(self.btn_pause); bar.addWidget(self.btn_reset); bar.addWidget(self.btn_finish)
+        bar.addStretch(1)
 
     def _apply_styles(self):
         self.setStyleSheet(f"""
@@ -192,172 +201,171 @@ class PomodoroPage(QtWidgets.QWidget):
             QLabel#title {{
                 font-size: 20px;
                 font-weight: 600;
+                padding-left: 2px;  /* Planner başlık hizası */
             }}
-            QFrame#card {{
+            QFrame#pane {{
                 background: {COLOR_SECONDARY_BG};
                 border: 1px solid #3a3a3a;
                 border-radius: 14px;
             }}
             QLabel#time {{
-                font-size: 56px;
-                font-weight: 700;
-                padding: 12px 0;
+                font-size: 64px;
+                font-weight: 800;
+                padding: 8px 0 12px 0;
             }}
-            QLineEdit#timeEdit {{
+            QLineEdit#edit_time {{
+                font-size: 64px;
+                font-weight: 800;
+                padding: 8px 0 12px 0;
+                border: none;
                 background: transparent;
-                border: 0;
-                font-size: 56px;
-                font-weight: 700;
-                padding: 12px 0;
                 color: {COLOR_TEXT};
+                selection-background-color: {COLOR_ACCENT};
             }}
-            QPushButton, QToolButton {{
-                background: {COLOR_ACCENT};
-                border: 0;
-                border-radius: 10px;
-                padding: 8px 14px;
-                color: {COLOR_TEXT};
-            }}
-            QPushButton:hover, QToolButton:hover {{ opacity: .9; }}
-            QComboBox {{
+            QComboBox, QListWidget, QTextEdit {{
                 background: {COLOR_PRIMARY_BG};
                 border: 1px solid #3a3a3a;
-                border-radius: 8px;
-                padding: 6px 8px;
+                border-radius: 10px;
                 color: {COLOR_TEXT};
             }}
-            QTextEdit#note {{
+            QToolButton {{
                 background: {COLOR_SECONDARY_BG};
                 border: 1px solid #3a3a3a;
-                border-radius: 8px;
+                border-radius: 10px;
                 padding: 8px;
-                color: {COLOR_TEXT};
             }}
+            QToolButton:hover {{ border-color: #4a4a4a; }}
         """)
 
-    # ------------------------------ Logic --------------------------------------
+    def _wire(self):
+        self.btn_start.clicked.connect(self._start)
+        self.btn_pause.clicked.connect(self._pause)
+        self.btn_reset.clicked.connect(self._reset)
+        self.btn_finish.clicked.connect(self._finish_early)
+
+        self.edit_time.editingFinished.connect(self._apply_edit_time)
+
+        self.cmb_tag.currentIndexChanged.connect(self._apply_filters)
+        self.cmb_proj.currentIndexChanged.connect(self._apply_filters)
+        self.list_tasks.itemSelectionChanged.connect(self._on_task_selected)
+
+    # ------------------------------ Tasks Sidebar -------------------------------
 
     def _normalize_tasks(self, tasks: Any) -> List[Dict[str, Any]]:
-        """
-        Gelen task liste yapısını normalize eder.
-        Kabul ettiği varyasyon örnekleri:
-          - [{'id': 1, 'title': 'X', 'tag':'A','project':'P','parent':'Y', ...}, ...]
-          - (id, title) tuple listesi
-        """
         out: List[Dict[str, Any]] = []
-        try:
-            for t in tasks or []:
-                if isinstance(t, dict):
-                    tid = t.get("id") or t.get("task_id")
-                    title = t.get("title") or t.get("name") or f"Task {tid}"
-                    tag = t.get("tag") or t.get("tag_name") or ""
-                    proj = t.get("project") or t.get("project_name") or ""
-                    parent = t.get("parent") or t.get("parent_title") or ""
-                    status = t.get("status") or t.get("state") or ""
-                elif isinstance(t, (tuple, list)) and len(t) >= 2:
-                    tid, title = t[0], t[1]
-                    tag = proj = parent = status = ""
-                else:
-                    continue
-                meta = ">"
-                meta_parts = [p for p in (tag, proj, parent) if p]
-                meta = ">".join(meta_parts) if meta_parts else ""
-                out.append({"id": tid, "title": title, "meta": meta, "tag": tag, "project": proj, "status": status})
-        except Exception:
-            pass
+        for t in tasks or []:
+            if isinstance(t, dict):
+                tid    = t.get("id") or t.get("task_id")
+                title  = t.get("title") or t.get("name") or f"Task {tid}"
+                tag    = t.get("tag") or t.get("tag_name") or ""
+                proj   = t.get("project") or t.get("project_name") or ""
+                parent = t.get("parent") or t.get("parent_title") or ""
+                status = t.get("status") or t.get("state") or ""
+            elif isinstance(t, (tuple, list)) and len(t) >= 2:
+                tid, title = t[0], t[1]
+                tag = proj = parent = status = ""
+            else:
+                continue
+            meta_parts = [p for p in (tag, proj, parent) if p]
+            meta = ">".join(meta_parts) if meta_parts else ""
+            out.append({"id": tid, "title": title, "tag": tag, "project": proj, "parent": parent, "meta": meta, "status": status})
         return out
 
-    def _fill_task_list(self, items: List[Dict[str, Any]]):
-        cur_id = self._current_task_id
-        self.lst_tasks.blockSignals(True)
-        self.lst_tasks.clear()
-        for t in items:
-            it = QtWidgets.QListWidgetItem(t["title"])
-            it.setData(QtCore.Qt.ItemDataRole.UserRole, t["id"])
-            meta = [p for p in (t.get("tag"), t.get("project")) if p]
-            if meta:
-                it.setToolTip(" / ".join(meta))
-            self.lst_tasks.addItem(it)
-        self.lst_tasks.blockSignals(False)
-        if cur_id is not None:
-            for i in range(self.lst_tasks.count()):
-                item = self.lst_tasks.item(i)
-                if item.data(QtCore.Qt.ItemDataRole.UserRole) == cur_id:
-                    self.lst_tasks.setCurrentItem(item)
-                    break
-
-    def _on_task_changed(self):
-        items = self.lst_tasks.selectedItems()
-        if items:
-            self._current_task_id = items[0].data(QtCore.Qt.ItemDataRole.UserRole)
-        else:
-            self._current_task_id = None
-
-    def _fill_tag_project(self):
-        tags = sorted({t.get("tag") for t in self._all_tasks if t.get("tag")})
-        projects = sorted({t.get("project") for t in self._all_tasks if t.get("project")})
-        self.cmb_tag.blockSignals(True)
-        self.cmb_tag.clear()
-        self.cmb_tag.addItem("Hepsi", userData=None)
-        for tag in tags:
-            self.cmb_tag.addItem(tag, userData=tag)
+    def _fill_tag_project_filters(self):
+        tags = sorted({t["tag"] for t in self._tasks_all if t.get("tag")})
+        self.cmb_tag.blockSignals(True); self.cmb_tag.clear(); self.cmb_tag.addItem("Tümü", userData=None)
+        for tg in tags: self.cmb_tag.addItem(tg, userData=tg)
         self.cmb_tag.blockSignals(False)
-        self.cmb_project.blockSignals(True)
-        self.cmb_project.clear()
-        self.cmb_project.addItem("Hepsi", userData=None)
-        for proj in projects:
-            self.cmb_project.addItem(proj, userData=proj)
-        self.cmb_project.blockSignals(False)
+
+        self._apply_filters()
 
     def _apply_filters(self):
-        tag = self.cmb_tag.currentData()
-        proj = self.cmb_project.currentData()
-        filtered = [t for t in self._all_tasks if (tag is None or t.get("tag") == tag) and (proj is None or t.get("project") == proj)]
-        self._fill_task_list(filtered)
+        sel_tag = self.cmb_tag.currentData()
+        filtered = [t for t in self._tasks_all if (sel_tag is None or t.get("tag")==sel_tag)]
+
+        projs = sorted({t["project"] for t in filtered if t.get("project")})
+        self.cmb_proj.blockSignals(True); self.cmb_proj.clear(); self.cmb_proj.addItem("Tümü", userData=None)
+        for pr in projs: self.cmb_proj.addItem(pr, userData=pr)
+        self.cmb_proj.blockSignals(False)
+
+        self._fill_task_list()
+
+    def _fill_task_list(self):
+        sel_tag = self.cmb_tag.currentData()
+        sel_proj= self.cmb_proj.currentData()
+
+        items = [t for t in self._tasks_all
+                 if (sel_tag is None or t.get("tag")==sel_tag)
+                 and (sel_proj is None or t.get("project")==sel_proj)]
+
+        self.list_tasks.clear()
+        for t in items:
+            txt = t["title"] if not t.get("meta") else f'{t["title"]} ({t["meta"]})'
+            it = QtWidgets.QListWidgetItem(txt)
+            it.setData(QtCore.Qt.ItemDataRole.UserRole, t["id"])
+            self.list_tasks.addItem(it)
+
+        # önceki seçimi muhafaza etmek istersen burada arayabilirsin.
+
+    def _on_task_selected(self):
+        it = self.list_tasks.currentItem()
+        self._current_task_id = it.data(QtCore.Qt.ItemDataRole.UserRole) if it else None
+
+    # ------------------------------ Timer Logic ---------------------------------
+
+    def _apply_edit_time(self):
+        text = (self.edit_time.text() or "").strip()
+        secs = self._parse_duration_text(text) if text else self._plan_secs
+        if secs <= 0: secs = 60
+        self._plan_secs = secs
+        if not self._running:
+            self._remaining = secs
+            self._elapsed_before_pause = 0
+        self._sync_labels()
+
+    def _parse_duration_text(self, text: str) -> int:
+        # "25" (dk), "25:00", "1:30:00" (hh:mm:ss) destekler
+        parts = [p for p in text.replace(" ", "").split(":") if p != ""]
+        if not parts:
+            return 0
+        if len(parts) == 1:
+            m = int(parts[0])
+            return max(0, m) * 60
+        if len(parts) == 2:
+            m, s = int(parts[0]), int(parts[1])
+            return m*60 + s
+        if len(parts) == 3:
+            h, m, s = int(parts[0]), int(parts[1]), int(parts[2])
+            return h*3600 + m*60 + s
+        return 0
 
     def _sync_labels(self):
         m, s = divmod(max(0, self._remaining), 60)
-        text = f"{m:02d}:{s:02d}"
-        self.lbl_time.setText(text)
-        self.edit_time.setText(text)
-
-    def _apply_edit_time(self):
-        text = self.edit_time.text().strip()
-        try:
-            if ":" in text:
-                m, s = text.split(":", 1)
-                mins = int(m)
-                secs = int(s)
-            else:
-                mins = int(text)
-                secs = 0
-        except ValueError:
-            return
-        self._plan_secs = mins * 60 + secs
-        if not self._running:
-            self._remaining = self._plan_secs
-            self._elapsed_before_pause = 0
-        self._sync_labels()
+        if self._running:
+            self.lbl_time.setText(f"{m:02d}:{s:02d}")
+        else:
+            # pre-start input'u da bu formata eşitle
+            self.edit_time.setText(f"{m:02d}:{s:02d}")
 
     def _start(self):
         if self._running:
             return
-        if self._current_task_id is None:
-            # Görev seçilmemişse yine de başlatılabilsin ama uyarı ver
-            QtWidgets.QToolTip.showText(self.mapToGlobal(QtCore.QPoint(0,0)), "Görev seçilmedi — yine de başlatıldı.")
+        # süreyi editörden güncelle
+        self._apply_edit_time()
         self._running = True
         self._tick_start_mono_ms = QtCore.QTime.currentTime().msecsSinceStartOfDay()
         self._timer.start()
+        self.stack_timer.setCurrentIndex(1)  # Running görünüme geç
         self.started.emit(self._current_task_id, self._plan_secs)
-        self._update_ui_state()
 
     def _pause(self):
         if not self._running:
             return
         self._timer.stop()
         self._running = False
-        self.paused.emit(self._current_task_id, self._elapsed_total())
-        self._update_ui_state()
+        self._elapsed_before_pause = self._elapsed_total()
+        self.stack_timer.setCurrentIndex(0)  # Pre-start görünümüne dön (süre editlenebilir)
+        self.paused.emit(self._current_task_id, self._elapsed_before_pause)
 
     def _reset(self):
         was_running = self._running
@@ -366,9 +374,14 @@ class PomodoroPage(QtWidgets.QWidget):
         self._running = False
         self._elapsed_before_pause = 0
         self._remaining = self._plan_secs
+        self.stack_timer.setCurrentIndex(0)
         self._sync_labels()
         self.reset.emit(self._current_task_id)
-        self._update_ui_state()
+
+    def _finish_early(self):
+        """Erken bitir: planı tamamlamadan seansı sonlandır."""
+        actual = self._elapsed_total() if self._running else self._elapsed_before_pause
+        self._finish_and_log(actual_secs=max(1, actual))
 
     def _elapsed_total(self) -> int:
         if not self._running:
@@ -382,30 +395,35 @@ class PomodoroPage(QtWidgets.QWidget):
             return
         self._remaining = max(0, self._remaining - 1)
         self._sync_labels()
-        if self._remaining == 0:
-            self._timer.stop()
-            self._running = False
-            self._elapsed_before_pause = 0
-            self.completed.emit(self._current_task_id, self._plan_secs)
-            self._log_pomodoro()
-            self._notify_done()
-            self._update_ui_state()
+        if self._remaining <= 0:
+            self._finish_and_log(actual_secs=self._plan_secs)
 
-    def _complete_now(self):
-        if not self._running:
-            return
+    def _finish_and_log(self, actual_secs: int):
+        # Sayaç durumu
         self._timer.stop()
         self._running = False
         self._elapsed_before_pause = 0
-        self._remaining = 0
-        self.completed.emit(self._current_task_id, self._plan_secs)
-        self._log_pomodoro()
-        self._notify_done()
-        self._update_ui_state()
+        self._remaining = self._plan_secs
+        self.stack_timer.setCurrentIndex(0)
+        self._sync_labels()
 
-    def _notify_done(self):
+        note = (self.txt_notes.toPlainText() or "").strip()
+        self.completed.emit(self._current_task_id, int(actual_secs), int(self._plan_secs), note)
+
+        # DB’ye yaz (varsa store)
         try:
-            # Basit bir görsel titreşim/renk animasyonu
+            if self._store and hasattr(self._store, "add_pomodoro_session"):
+                self._store.add_pomodoro_session(
+                    task_id=self._current_task_id,
+                    planned_secs=int(self._plan_secs),
+                    actual_secs=int(actual_secs),
+                    note=note
+                )
+        except Exception:
+            pass
+
+        # Görsel bir feedback
+        try:
             eff = QtWidgets.QGraphicsColorizeEffect(self)
             eff.setColor(QtGui.QColor(COLOR_ACCENT))
             self.setGraphicsEffect(eff)
@@ -413,17 +431,5 @@ class PomodoroPage(QtWidgets.QWidget):
         except Exception:
             pass
 
-    def _log_pomodoro(self):
-        note = self.note_edit.toPlainText()
-        if self._store and hasattr(self._store, "log_pomodoro"):
-            try:
-                self._store.log_pomodoro(self._current_task_id, note, self._plan_secs)
-            except Exception:
-                pass
-        self.note_edit.clear()
-
-    def _update_ui_state(self):
-        if self._running:
-            self.time_stack.setCurrentIndex(1)
-        else:
-            self.time_stack.setCurrentIndex(0)
+        # Notu temizlemek istersen (yorum satırını kaldır)
+        # self.txt_notes.clear()

--- a/services/sync_orchestrator.py
+++ b/services/sync_orchestrator.py
@@ -3,6 +3,7 @@ from typing import Optional
 from PyQt6 import QtCore
 from services.local_db import LocalDB
 import services.supabase_api as api
+from datetime import datetime, timedelta
 
 class SyncOrchestrator(QtCore.QObject):
     tasksUpdated  = QtCore.pyqtSignal(list)
@@ -135,6 +136,23 @@ class SyncOrchestrator(QtCore.QObject):
 
     def get_linked_tasks(self, task_id: int):
         return self.db.get_linked_tasks(task_id)
+
+    def add_pomodoro_session(self, task_id: int | None, planned_secs: int, actual_secs: int, note: str):
+        if not task_id:
+            return
+        now = datetime.utcnow()
+        started = now - timedelta(seconds=int(actual_secs))
+        self.db.insert_pomodoro_session(
+            task_id=int(task_id),
+            started_at_iso=started.isoformat(timespec="seconds"),
+            ended_at_iso=now.isoformat(timespec="seconds"),
+            planned_secs=int(planned_secs),
+            actual_secs=int(actual_secs),
+            note=note or "",
+        )
+
+    def get_pomodoro_sessions(self, task_id: int) -> list[dict]:
+        return self.db.list_pomodoro_sessions_for_task(int(task_id))
 
     # ---------- helpers ----------
     def _emit_all_from_local(self):


### PR DESCRIPTION
## Summary
- replace pomodoro page with planner-styled timer, note pad, task filters and control bar
- store completed Pomodoro sessions in SQLite and expose via store API
- show per-task Pomodoro history in the task dialog's new right column and refresh after sessions

## Testing
- `python -m py_compile pages/pomodoro_page.py services/local_db.py services/sync_orchestrator.py widgets/dialogs/event_task_dialog.py pages/planner_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68a133fd5cfc83288b9166a02799859a