### PR TITLE
Connect Pomodoro page to planner store

### DIFF
--- a/windows/main_window.py
+++ b/windows/main_window.py
@@ -6,7 +6,6 @@ from pages.planner_page import PlannerPage
 from pages.health_activity_page import HealthActivityPage
 from pages.performance_page import PerformancePage
 from pages.journal_page import JournalPage
-from pages.pomodoro_page import PomodoroPage
 
 from theme.colors import COLOR_PRIMARY_BG
 from utils.icons import make_app_icon_png
@@ -49,7 +48,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.page_health = HealthActivityPage()
         self.page_perf   = PerformancePage()
         self.page_journal= JournalPage()
-        self.page_pomo   = PomodoroPage()
+        self.page_pomo   = self.page_planner.pomo
 
         # Stack'e ekle
         self.pages = {}


### PR DESCRIPTION
## Summary
- Reuse the PomodoroPage instance from PlannerPage in the main window so it has access to the shared store

## Testing
- `python -m py_compile windows/main_window.py`
- `python -m py_compile pages/pomodoro_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68a13a226ba083289428384af0a08b7d