### PR TITLE
Improve Pomodoro task sidebar integration with store

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -689,6 +689,11 @@ class PlannerPage(QtWidgets.QWidget):
         self._all_tasks = tasks or []
         self._update_project_buttons()
         self._filter_tasks_and_update()
+        if hasattr(self, "pomo"):
+            try:
+                self.pomo.reload_sidebar()
+            except Exception:
+                pass
 
     def _apply_events(self, events: list[dict]):
         self._all_events = events or []


### PR DESCRIPTION
## Summary
- Load tasks for Pomodoro directly from the store's database
- Map tag and project IDs to names and relax "in progress" filtering
- Refresh Pomodoro sidebar when planner tasks change

## Testing
- `python -m py_compile pages/pomodoro_page.py pages/planner_page.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a13c97ea188328be0729194540656f