### PR TITLE
Enhance Pomodoro UI and behavior

### DIFF
--- a/pages/planner_page.py
+++ b/pages/planner_page.py
@@ -298,6 +298,8 @@ class PlannerPage(QtWidgets.QWidget):
         self.pomo = PomodoroPage()
         self.pomo.set_store(self.store)
         self.pomo.completed.connect(self._on_pomo_completed)
+        if hasattr(self.pomo, "taskActivated"):
+            self.pomo.taskActivated.connect(self._open_task_dialog_by_id)
 
         if hasattr(self.kanban, "statusChanged"):
             self.kanban.statusChanged.connect(self.store.set_task_status)

--- a/widgets/dialogs/event_task_dialog.py
+++ b/widgets/dialogs/event_task_dialog.py
@@ -383,11 +383,25 @@ class EventTaskDialog(QtWidgets.QDialog):
             except Exception:
                 ended = None
             dur_m = int(max(1, s["actual_secs"])) // 60
-            plan_m = int(max(1, s["planned_secs"])) // 60
-            title = f"{ended.strftime('%d %b %H:%M') if ended else s['ended_at']} — {dur_m}m (plan:{plan_m}m)"
-            it = QtWidgets.QListWidgetItem(title)
+            left = ended.strftime('%Y-%m-%d %H:%M') if ended else s['ended_at']
+            it = QtWidgets.QListWidgetItem()
             it.setData(QtCore.Qt.ItemDataRole.UserRole, s)
+
+            w = QtWidgets.QWidget()
+            row = QtWidgets.QHBoxLayout(w)
+            row.setContentsMargins(8, 6, 8, 6)
+            row.setSpacing(8)
+
+            lbl_left = QtWidgets.QLabel(left)
+            lbl_right = QtWidgets.QLabel(f"{dur_m}m")
+            lbl_right.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+            row.addWidget(lbl_left, 1)
+            row.addWidget(lbl_right, 1)
+
             self.list_pomo.addItem(it)
+            self.list_pomo.setItemWidget(it, w)
+            it.setSizeHint(QtCore.QSize(self.list_pomo.viewport().width() - 12, max(40, w.sizeHint().height())))
 
     def showEvent(self, ev):
         super().showEvent(ev)


### PR DESCRIPTION
## Summary
- Style Pomodoro sidebar headers with muted color and remove punctuation for cleaner look.
- Show task due dates and allow opening tasks from Pomodoro list.
- Keep timer state on pause and improve pomodoro history layout in event dialog.

## Testing
- `python -m py_compile pages/pomodoro_page.py widgets/dialogs/event_task_dialog.py pages/planner_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68a26b6ebd9c8328b6c80a3a5b7e88ed