### PR TITLE
feat(ios): add supabase-backed calendar

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct PlannerEvent: Identifiable, Codable, Hashable {
+    public var id: UUID
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var status: String?
+    public init(id: UUID = UUID(), title: String, start: Date, end: Date, status: String? = nil) {
+        self.id = id
+        self.title = title
+        self.start = start
+        self.end = end
+        self.status = status
+    }
+}

--- a/ios/Services/EventStore.swift
+++ b/ios/Services/EventStore.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+public final class EventStore: ObservableObject {
+    @Published public var events: [PlannerEvent] = []
+    private let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("events.json")
+    }()
+    public init() { load() }
+
+    public func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([PlannerEvent].self, from: data) {
+            events = decoded
+        }
+    }
+
+    public func save() {
+        if let data = try? JSONEncoder().encode(events) {
+            try? data.write(to: fileURL)
+        }
+    }
+
+    public func events(for day: Date) -> [PlannerEvent] {
+        let cal = Calendar.current
+        return events.filter { cal.isDate($0.start, inSameDayAs: day) }
+            .sorted { $0.start < $1.start }
+    }
+
+    public func move(from offsets: IndexSet, to offset: Int, on day: Date) {
+        var daily = events(for: day)
+        daily.move(fromOffsets: offsets, toOffset: offset)
+        events.removeAll { Calendar.current.isDate($0.start, inSameDayAs: day) }
+        events.append(contentsOf: daily)
+        save()
+    }
+
+    public func syncFromSupabase() async {
+        if let remote = try? await SupabaseService.shared.fetchEvents() {
+            DispatchQueue.main.async {
+                self.events = remote
+                self.save()
+            }
+        }
+    }
+
+    public func backupToSupabase() async {
+        try? await SupabaseService.shared.upsertEvents(events)
+    }
+}

--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -4,9 +4,9 @@ public struct SupabaseConfig { public static var url = ""; public static var ano
 
 public final class SupabaseService {
     public static let shared = SupabaseService(); private init() {}
-    private func request(path: String, method: String = "POST", body: Data?) -> URLRequest? {
-        guard let base = URL(string: SupabaseConfig.url)?.appendingPathComponent("/rest/v1").appendingPathComponent(path) else { return nil }
-        var req = URLRequest(url: base)
+    private func request(path: String, method: String = "POST", body: Data? = nil) -> URLRequest? {
+        guard let url = URL(string: "\(SupabaseConfig.url)/rest/v1/\(path)") else { return nil }
+        var req = URLRequest(url: url)
         req.httpMethod = method
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("Bearer \(SupabaseConfig.anonKey)", forHTTPHeaderField: "Authorization")
@@ -14,6 +14,19 @@ public final class SupabaseService {
         req.setValue("return=minimal", forHTTPHeaderField: "Prefer")
         req.httpBody = body
         return req
+    }
+    public func fetchEvents() async throws -> [PlannerEvent] {
+        guard let req = request(path: "events?select=*", method: "GET") else { return [] }
+        let (data, _) = try await URLSession.shared.data(for: req)
+        let dec = JSONDecoder(); dec.dateDecodingStrategy = .iso8601
+        return try dec.decode([PlannerEvent].self, from: data)
+    }
+    public func upsertEvents(_ items: [PlannerEvent]) async throws {
+        let enc = JSONEncoder(); enc.dateEncodingStrategy = .iso8601
+        let data = try enc.encode(items)
+        if let req = request(path: "events", body: data) {
+            _ = try await URLSession.shared.data(for: req)
+        }
     }
     public func uploadWeeklyEnergy(userId: String, items: [DayEnergy]) async {
         let rows: [[String: Any]] = items.map { [

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+public struct KanbanPage: View {
+    public init() {}
+    public var body: some View {
+        Text("Kanban coming soon")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Theme.primaryBG)
+    }
+}


### PR DESCRIPTION
## Summary
- add `PlannerEvent` model and local `EventStore`
- extend `SupabaseService` to fetch and upsert events
- replace calendar view with Supabase data, Kanban entry, and backup support

## Testing
- `swift --version`
- `swiftc ios/Views/Calendar/CalendarPage.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68a90befe60883289e28d787c288541d