### PR TITLE
Fix dynamic DatePicker style selection

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -18,9 +18,15 @@ public struct CalendarPage: View {
                 .pickerStyle(.segmented)
                 .padding([.horizontal, .top])
 
-                DatePicker("", selection: $selectedDate, displayedComponents: .date)
-                    .datePickerStyle(mode == .week ? .compact : .graphical)
-                    .padding(.horizontal)
+                if mode == .week {
+                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                        .datePickerStyle(.compact)
+                        .padding(.horizontal)
+                } else {
+                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                        .datePickerStyle(.graphical)
+                        .padding(.horizontal)
+                }
 
                 List {
                     ForEach(store.events(for: selectedDate)) { ev in


### PR DESCRIPTION
## Summary
- conditionally apply Compact or Graphical DatePicker styles to avoid type mismatch

## Testing
- `swift --version`
- `swiftc -typecheck ios/Views/Calendar/CalendarPage.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a90e582dd083289f6c7a60e546c1a3