### PR TITLE
feat: improve ios calendar and kanban views

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -6,11 +6,21 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
     public var start: Date
     public var end: Date
     public var status: String?
-    public init(id: UUID = UUID(), title: String, start: Date, end: Date, status: String? = nil) {
+    public var tag: String?
+    public var project: String?
+    public init(id: UUID = UUID(),
+                title: String,
+                start: Date,
+                end: Date,
+                status: String? = nil,
+                tag: String? = nil,
+                project: String? = nil) {
         self.id = id
         self.title = title
         self.start = start
         self.end = end
         self.status = status
+        self.tag = tag
+        self.project = project
     }
 }

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -5,6 +5,8 @@ public struct CalendarPage: View {
     @State private var selectedDate = Date()
     @State private var showKanban = false
     @State private var mode: Mode = .week
+    @State private var selectedTag: String?
+    @State private var selectedProject: String?
 
     enum Mode: String, CaseIterable { case day = "Gün", week = "Hafta" }
     public init() {}
@@ -18,28 +20,31 @@ public struct CalendarPage: View {
                 .pickerStyle(.segmented)
                 .padding([.horizontal, .top])
 
-                if mode == .week {
-                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
-                        .datePickerStyle(.compact)
-                        .padding(.horizontal)
-                } else {
-                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
-                        .datePickerStyle(.graphical)
-                        .padding(.horizontal)
-                }
-
-                List {
-                    ForEach(store.events(for: selectedDate)) { ev in
-                        VStack(alignment: .leading) {
-                            Text(ev.title).font(.headline)
-                            Text("\(ev.start.formatted(date: .omitted, time: .shortened)) - \(ev.end.formatted(date: .omitted, time: .shortened))")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
+                HStack {
+                    Picker("Tag", selection: $selectedTag) {
+                        Text("Tümü").tag(String?.none)
+                        ForEach(Array(Set(store.events.compactMap { $0.tag })), id: \.self) { t in
+                            Text(t).tag(String?.some(t))
                         }
                     }
-                    .onMove { idx, dest in store.move(from: idx, to: dest, on: selectedDate) }
+                    Picker("Proje", selection: $selectedProject) {
+                        Text("Tümü").tag(String?.none)
+                        ForEach(Array(Set(store.events.compactMap { $0.project })), id: \.self) { p in
+                            Text(p).tag(String?.some(p))
+                        }
+                    }
                 }
-                .listStyle(.plain)
+                .padding(.horizontal)
+
+                if mode == .week {
+                    WeekView(selectedDate: $selectedDate,
+                             events: store.events,
+                             tag: selectedTag,
+                             project: selectedProject)
+                } else {
+                    DayTimelineView(date: selectedDate,
+                                    events: filteredEvents(for: selectedDate))
+                }
             }
             .navigationTitle("Takvim")
             .toolbar {
@@ -49,9 +54,72 @@ public struct CalendarPage: View {
                     Button("Yedekle") { Task { await store.backupToSupabase() } }
                 }
             }
-            .sheet(isPresented: $showKanban) { KanbanPage() }
+            .sheet(isPresented: $showKanban) { KanbanPage(store: store) }
             .task { await store.syncFromSupabase() }
             .background(Theme.primaryBG.ignoresSafeArea())
+        }
+    }
+    private func filteredEvents(for day: Date) -> [PlannerEvent] {
+        store.events(for: day).filter { ev in
+            (selectedTag == nil || ev.tag == selectedTag) &&
+            (selectedProject == nil || ev.project == selectedProject)
+        }
+    }
+}
+
+private func weekDates(containing date: Date) -> [Date] {
+    let cal = Calendar.current
+    let start = cal.date(from: cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date))!
+    return (0..<7).compactMap { cal.date(byAdding: .day, value: $0, to: start) }
+}
+
+private struct DayTimelineView: View {
+    var date: Date
+    var events: [PlannerEvent]
+    var body: some View {
+        List {
+            ForEach(0..<24, id: \.self) { hr in
+                let hourEvents = events.filter { Calendar.current.component(.hour, from: $0.start) == hr }
+                Section(header: Text("\(hr):00").foregroundColor(Theme.text)) {
+                    ForEach(hourEvents) { ev in
+                        VStack(alignment: .leading) {
+                            Text(ev.title).foregroundColor(Theme.text).font(.headline)
+                            Text("\(ev.start.formatted(date: .omitted, time: .shortened)) - \(ev.end.formatted(date: .omitted, time: .shortened))")
+                                .foregroundColor(Theme.textMuted).font(.caption)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+private struct WeekView: View {
+    @Binding var selectedDate: Date
+    var events: [PlannerEvent]
+    var tag: String?
+    var project: String?
+    var body: some View {
+        let week = weekDates(containing: selectedDate)
+        let groups = stride(from: 0, to: week.count, by: 3).map { Array(week[$0..<min($0 + 3, week.count)]) }
+        TabView {
+            ForEach(groups, id: \.self) { group in
+                HStack(spacing: 0) {
+                    ForEach(group, id: \.self) { day in
+                        DayTimelineView(date: day,
+                                        events: eventsFor(day: day))
+                            .frame(width: UIScreen.main.bounds.width / 3)
+                    }
+                }
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .automatic))
+    }
+    private func eventsFor(day: Date) -> [PlannerEvent] {
+        let store = EventStore(); store.events = events
+        return store.events(for: day).filter { ev in
+            (tag == nil || ev.tag == tag) && (project == nil || ev.project == project)
         }
     }
 }

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -1,10 +1,41 @@
 import SwiftUI
 
+private struct KanbanColumn: View {
+    var title: String
+    var events: [PlannerEvent]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .foregroundColor(Theme.text)
+                .font(.headline)
+            ForEach(events) { ev in
+                Text(ev.title)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Theme.secondaryBG)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .foregroundColor(Theme.text)
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(width: 200)
+        .background(Theme.primaryBG)
+    }
+}
+
 public struct KanbanPage: View {
-    public init() {}
+    @ObservedObject var store: EventStore
+    public init(store: EventStore) { self.store = store }
     public var body: some View {
-        Text("Kanban coming soon")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Theme.primaryBG)
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: 12) {
+                KanbanColumn(title: "Yapılacak", events: store.events.filter { $0.status == "todo" || $0.status == nil })
+                KanbanColumn(title: "Yapılıyor", events: store.events.filter { $0.status == "doing" })
+                KanbanColumn(title: "Bitti", events: store.events.filter { $0.status == "done" })
+            }
+            .padding()
+        }
+        .background(Theme.primaryBG.ignoresSafeArea())
     }
 }


### PR DESCRIPTION
## Summary
- add tag and project fields for planner events
- enhance iOS calendar with filtering, hourly and weekly views
- implement basic Kanban board showing tasks by status

## Testing
- `swiftc -parse ios/Views/Calendar/CalendarPage.swift ios/Views/Kanban/KanbanPage.swift ios/Services/EventStore.swift ios/Models/Event.swift ios/Services/SupabaseService.swift`


------
https://chatgpt.com/codex/tasks/task_e_68a917b210c48328a6b302ac16499327