### PR TITLE
Add date navigation and grid calendar, revamp Kanban layout

### DIFF
--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -8,34 +8,66 @@ private struct KanbanColumn: View {
             Text(title)
                 .foregroundColor(Theme.text)
                 .font(.headline)
-            ForEach(events) { ev in
-                Text(ev.title)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Theme.secondaryBG)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .foregroundColor(Theme.text)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(events) { ev in
+                        Text(ev.title)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Theme.secondaryBG)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .foregroundColor(Theme.text)
+                    }
+                }
             }
-            Spacer()
+            .frame(maxHeight: 200)
         }
         .padding()
-        .frame(width: 200)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.primaryBG)
     }
 }
 
 public struct KanbanPage: View {
     @ObservedObject var store: EventStore
+    @State private var selectedTag: String?
+    @State private var selectedProject: String?
     public init(store: EventStore) { self.store = store }
     public var body: some View {
-        ScrollView(.horizontal) {
-            HStack(alignment: .top, spacing: 12) {
-                KanbanColumn(title: "Yapılacak", events: store.events.filter { $0.status == "todo" || $0.status == nil })
-                KanbanColumn(title: "Yapılıyor", events: store.events.filter { $0.status == "doing" })
-                KanbanColumn(title: "Bitti", events: store.events.filter { $0.status == "done" })
+        VStack {
+            HStack {
+                Picker("Tag", selection: $selectedTag) {
+                    Text("Tümü").tag(String?.none)
+                    ForEach(Array(Set(store.events.compactMap { $0.tag })), id: \.self) { t in
+                        Text(t).tag(String?.some(t))
+                    }
+                }
+                Picker("Proje", selection: $selectedProject) {
+                    Text("Tümü").tag(String?.none)
+                    ForEach(Array(Set(store.events.compactMap { $0.project })), id: \.self) { p in
+                        Text(p).tag(String?.some(p))
+                    }
+                }
             }
             .padding()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    KanbanColumn(title: "Yapılacak", events: filtered(status: "todo"))
+                    KanbanColumn(title: "Yapılıyor", events: filtered(status: "doing"))
+                    KanbanColumn(title: "Bitti", events: filtered(status: "done"))
+                }
+                .padding(.horizontal)
+            }
         }
         .background(Theme.primaryBG.ignoresSafeArea())
+    }
+    private func filtered(status: String) -> [PlannerEvent] {
+        store.events.filter { ev in
+            let st = ev.status ?? "todo"
+            return st == status &&
+                (selectedTag == nil || ev.tag == selectedTag) &&
+                (selectedProject == nil || ev.project == selectedProject) &&
+                ev.title != ev.tag && ev.title != ev.project
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add date picker for quick navigation in calendar
- render day and week calendar views in a grid with day labels
- stack Kanban lanes vertically with tag/project filters and remove spurious tag/project cards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a92a47e02083288b8581850b7cc1e5