### PR TITLE
Improve iOS planner week view and Kanban tasks

### DIFF
--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct PlannerTask: Identifiable, Codable, Hashable {
+    public var id: Int
+    public var title: String
+    public var status: String?
+    public var tag: String?
+    public var project: String?
+    public init(id: Int = Int(Date().timeIntervalSince1970),
+                title: String,
+                status: String? = nil,
+                tag: String? = nil,
+                project: String? = nil) {
+        self.id = id
+        self.title = title
+        self.status = status
+        self.tag = tag
+        self.project = project
+    }
+}

--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+public final class TaskStore: ObservableObject {
+    @Published public var tasks: [PlannerTask] = []
+    private let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("tasks.json")
+    }()
+    public init() { load() }
+
+    public func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([PlannerTask].self, from: data) {
+            tasks = decoded
+        }
+    }
+
+    public func save() {
+        if let data = try? JSONEncoder().encode(tasks) {
+            try? data.write(to: fileURL)
+        }
+    }
+
+    public func syncFromSupabase() async {
+        if let remote = try? await SupabaseService.shared.fetchTasks() {
+            DispatchQueue.main.async {
+                self.tasks = remote
+                self.save()
+            }
+        }
+    }
+
+    public func backupToSupabase() async {
+        try? await SupabaseService.shared.upsertTasks(tasks)
+    }
+}


### PR DESCRIPTION
## Summary
- Display week calendar with hour labels and groups of up to three days
- Span events across their full duration in the week view
- Introduce task model/store and show tasks on Kanban board

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a92eb9b2d483289d7f8d5b4584f86b