### PR TITLE
Improve calendar UI and Kanban task fetch

### DIFF
--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -73,7 +73,10 @@ public final class SupabaseService {
     }
     public func fetchTasks() async throws -> [PlannerTask] {
         let fields = "id,title,status,tag:tags(name),project:projects(name)"
-        let path = "tasks?select=\(fields)&has_time=eq.false"
+        // Fetch tasks that do not have an assigned time range. In the
+        // Supabase table these are stored either with `has_time = false`
+        // or with a `NULL` value, so include both conditions.
+        let path = "tasks?select=\(fields)&or=(has_time.eq.false,has_time.is.null)"
         guard let req = request(path: path, method: "GET") else { return [] }
         let (data, _) = try await URLSession.shared.data(for: req)
         let dec = JSONDecoder()

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -43,17 +43,26 @@ public struct CalendarPage: View {
                              events: store.events,
                              tag: selectedTag,
                              project: selectedProject)
+                    .padding(.horizontal)
                 } else {
                     DayTimelineView(date: selectedDate,
                                     events: filteredEvents(for: selectedDate))
+                    .padding(.horizontal)
                 }
+
+                Button("Kanban") { showKanban = true }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Theme.secondaryBG)
+                    .foregroundColor(Theme.text)
+                    .padding([.horizontal, .bottom])
             }
             .navigationTitle("Takvim")
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) { EditButton() }
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button("Kanban") { showKanban = true }
-                    Button("Yedekle") { Task { await store.backupToSupabase() } }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { Task { await store.syncFromSupabase() } }) {
+                        Image(systemName: "arrow.clockwise")
+                    }
                 }
             }
             .sheet(isPresented: $showKanban) { KanbanPage() }


### PR DESCRIPTION
## Summary
- Include tasks without `has_time` in Supabase fetch for Kanban
- Refresh icon in calendar toolbar and bottom Kanban button with padding

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2342ec988328aaf6dc926872371b