### PR TITLE
Fix Kanban task filtering and overhaul calendar layout

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -44,10 +44,12 @@ public struct CalendarPage: View {
                              tag: selectedTag,
                              project: selectedProject)
                     .padding(.horizontal)
+                    .environmentObject(store)
                 } else {
                     DayTimelineView(date: selectedDate,
                                     events: filteredEvents(for: selectedDate))
                     .padding(.horizontal)
+                    .environmentObject(store)
                 }
 
                 Button("Kanban") { showKanban = true }
@@ -58,6 +60,7 @@ public struct CalendarPage: View {
                     .padding([.horizontal, .bottom])
             }
             .navigationTitle("Takvim")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { Task { await store.syncFromSupabase() } }) {
@@ -84,43 +87,111 @@ private func weekDates(containing date: Date) -> [Date] {
     return (0..<7).compactMap { cal.date(byAdding: .day, value: $0, to: start) }
 }
 
+private struct DayColumn: View {
+    @EnvironmentObject var store: EventStore
+    let day: Date
+    let events: [PlannerEvent]
+    let rowHeight: CGFloat
+    var body: some View {
+        GeometryReader { geo in
+            let dayWidth = geo.size.width
+            ZStack(alignment: .topLeading) {
+                VStack(spacing: 0) {
+                    ForEach(0..<24, id: \.self) { _ in
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                            .frame(height: 0.5)
+                            .offset(y: rowHeight - 0.5)
+                            .frame(height: rowHeight)
+                    }
+                }
+                ForEach(events) { ev in
+                    let y = yOffset(for: ev.start, rowHeight: rowHeight)
+                    let h = height(for: ev, rowHeight: rowHeight)
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Theme.secondaryBG)
+                        .overlay(
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(ev.title).font(.caption).foregroundColor(Theme.text)
+                                Text(timeRange(ev)).font(.system(size: 10)).foregroundColor(Theme.textMuted)
+                            }
+                            .padding(6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        )
+                        .frame(height: h)
+                        .offset(y: y)
+                        .gesture(dragGesture(for: ev, day: day, rowHeight: rowHeight, dayWidth: dayWidth))
+                }
+            }
+            .frame(minHeight: rowHeight * 24, alignment: .top)
+        }
+    }
+    private func yOffset(for start: Date, rowHeight: CGFloat) -> CGFloat {
+        let comps = Calendar.current.dateComponents([.hour, .minute], from: start)
+        let h = CGFloat(comps.hour ?? 0)
+        let m = CGFloat(comps.minute ?? 0) / 60
+        return (h + m) * rowHeight
+    }
+    private func height(for ev: PlannerEvent, rowHeight: CGFloat) -> CGFloat {
+        let dur = ev.end.timeIntervalSince(ev.start) / 3600
+        return CGFloat(dur) * rowHeight
+    }
+    private func timeRange(_ ev: PlannerEvent) -> String {
+        "\(ev.start.formatted(date: .omitted, time: .shortened)) - \(ev.end.formatted(date: .omitted, time: .shortened))"
+    }
+    private func dragGesture(for ev: PlannerEvent, day: Date, rowHeight: CGFloat, dayWidth: CGFloat) -> some Gesture {
+        DragGesture()
+            .onEnded { value in
+                let minuteDelta = Int((value.translation.height / rowHeight) * 60)
+                let dayDelta = Int((value.translation.width / dayWidth).rounded())
+                let cal = Calendar.current
+                var newStart = cal.date(byAdding: .minute, value: minuteDelta, to: ev.start) ?? ev.start
+                var newEnd = cal.date(byAdding: .minute, value: minuteDelta, to: ev.end) ?? ev.end
+                if dayDelta != 0 {
+                    newStart = cal.date(byAdding: .day, value: dayDelta, to: newStart) ?? newStart
+                    newEnd = cal.date(byAdding: .day, value: dayDelta, to: newEnd) ?? newEnd
+                }
+                if let idx = store.events.firstIndex(where: { $0.id == ev.id }) {
+                    store.events[idx].start = newStart
+                    store.events[idx].end = newEnd
+                    store.save()
+                    Task { await store.backupToSupabase() }
+                }
+            }
+    }
+}
+
 private struct DayTimelineView: View {
+    @EnvironmentObject var store: EventStore
     var date: Date
     var events: [PlannerEvent]
+    let rowHeight: CGFloat = 60
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(0..<24, id: \.self) { hr in
-                    let hourEvents = events.filter { Calendar.current.component(.hour, from: $0.start) == hr }
-                    VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .top, spacing: 0) {
+                VStack(spacing: 0) {
+                    ForEach(0..<24, id: \.self) { hr in
                         Text("\(hr):00")
+                            .frame(width: 40, height: rowHeight, alignment: .topLeading)
                             .foregroundColor(Theme.text)
                             .font(.caption)
-                        ForEach(hourEvents) { ev in
-                            VStack(alignment: .leading) {
-                                Text(ev.title).foregroundColor(Theme.text).font(.headline)
-                                Text("\(ev.start.formatted(date: .omitted, time: .shortened)) - \(ev.end.formatted(date: .omitted, time: .shortened))")
-                                    .foregroundColor(Theme.textMuted).font(.caption)
-                            }
-                        }
-                        Spacer()
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(4)
-                    .frame(height: 60, alignment: .top)
-                    .border(Color.gray.opacity(0.3), width: 0.5)
                 }
+                DayColumn(day: date, events: events, rowHeight: rowHeight)
+                    .frame(maxWidth: .infinity)
             }
         }
     }
 }
 
 private struct WeekView: View {
+    @EnvironmentObject var store: EventStore
     @Binding var selectedDate: Date
     var events: [PlannerEvent]
     var tag: String?
     var project: String?
     @State private var page = 0
+    let rowHeight: CGFloat = 60
     private let dayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "E dd"; return f
     }()
@@ -142,30 +213,20 @@ private struct WeekView: View {
                     }
                     .padding(.vertical, 4)
                     ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(0..<24, id: \.self) { hr in
-                                HStack(spacing: 0) {
+                        HStack(alignment: .top, spacing: 0) {
+                            VStack(spacing: 0) {
+                                ForEach(0..<24, id: \.self) { hr in
                                     Text("\(hr):00")
-                                        .frame(width: 40, alignment: .leading)
+                                        .frame(width: 40, height: rowHeight, alignment: .topLeading)
                                         .foregroundColor(Theme.text)
                                         .font(.caption)
-                                    ForEach(days, id: \.self) { day in
-                                        let evs = eventsFor(day: day, hour: hr)
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            ForEach(evs) { ev in
-                                                Text(ev.title)
-                                                    .font(.caption)
-                                                    .foregroundColor(Theme.text)
-                                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                            }
-                                            Spacer()
-                                        }
-                                        .frame(maxWidth: .infinity, alignment: .topLeading)
-                                        .padding(4)
-                                        .border(Color.gray.opacity(0.3), width: 0.5)
-                                    }
                                 }
-                                .frame(height: 60)
+                            }
+                            ForEach(days, id: \.self) { day in
+                                DayColumn(day: day,
+                                          events: eventsFor(day: day),
+                                          rowHeight: rowHeight)
+                                    .frame(width: 100)
                             }
                         }
                     }
@@ -178,6 +239,13 @@ private struct WeekView: View {
             if let idx = groups.firstIndex(where: { $0.contains(selectedDate) }) { page = idx }
         }
     }
+    private func eventsFor(day: Date) -> [PlannerEvent] {
+        events.filter { ev in
+            Calendar.current.isDate(ev.start, inSameDayAs: day) &&
+            (tag == nil || ev.tag == tag) &&
+            (project == nil || ev.project == project)
+        }
+    }
     private func grouped(_ days: [Date]) -> [[Date]] {
         var result: [[Date]] = []
         var index = 0
@@ -187,15 +255,5 @@ private struct WeekView: View {
             index += 3
         }
         return result
-    }
-    private func eventsFor(day: Date, hour: Int) -> [PlannerEvent] {
-        let cal = Calendar.current
-        let hourStart = cal.date(bySettingHour: hour, minute: 0, second: 0, of: day)!
-        let hourEnd = cal.date(byAdding: .hour, value: 1, to: hourStart)!
-        return events.filter { ev in
-            cal.isDate(ev.start, inSameDayAs: day) &&
-            ev.start < hourEnd && ev.end > hourStart &&
-            (tag == nil || ev.tag == tag) && (project == nil || ev.project == project)
-        }
     }
 }

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -67,8 +67,7 @@ public struct KanbanPage: View {
             let st = task.status ?? "todo"
             return st == status &&
                 (selectedTag == nil || task.tag == selectedTag) &&
-                (selectedProject == nil || task.project == selectedProject) &&
-                task.title != task.tag && task.title != task.project
+                (selectedProject == nil || task.project == selectedProject)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure Kanban lists include tasks regardless of duplicate title/tag/project
- Keep calendar refresh button inline with "Takvim" title
- Replace hourly grid with draggable event blocks in day and week calendar views

## Testing
- `swift --version`
- `swiftc ios/Views/Calendar/CalendarPage.swift ios/Views/Kanban/KanbanPage.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68aa26c323508328a97f5a2794ea527a