### PR TITLE
Refine calendar interactions and styling

### DIFF
--- a/ios/UI/Theme.swift
+++ b/ios/UI/Theme.swift
@@ -4,6 +4,7 @@ public struct Theme {
     public static let primaryBG = Color(hex: "#212121")
     public static let secondaryBG = Color(hex: "#2d2d2d")
     public static let accent      = Color(hex: "#11989C")
+    public static let accentBG    = Theme.accent.opacity(0.3)
     public static let text        = Color(hex: "#EEEEEE")
     public static let textMuted   = Color(hex: "#AEAEAE")
 }


### PR DESCRIPTION
## Summary
- Snap calendar event drags to 15-minute increments
- Restyle small events and unify padding and header layout
- Rework week view to paginate by day with column separators

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2bb461448328a4d84e4d6e1979aa