### PR TITLE
Guard WeekView overlay against empty days

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -240,18 +240,20 @@ private struct WeekView: View {
                             }
                         }
                         .overlay(alignment: .topLeading) {
-                            GeometryReader { geo in
-                                let w = geo.size.width
-                                let colCount = Double(days.count)
-                                let step = w / colCount
-                                Path { p in
-                                    for i in 1..<Int(colCount) {
-                                        let x = CGFloat(i) * step
-                                        p.move(to: CGPoint(x: x, y: 0))
-                                        p.addLine(to: CGPoint(x: x, y: geo.size.height))
+                            if !days.isEmpty {
+                                GeometryReader { geo in
+                                    let w = geo.size.width
+                                    let colCount = Double(days.count)
+                                    let step = w / colCount
+                                    Path { p in
+                                        for i in 1..<Int(colCount) {
+                                            let x = CGFloat(i) * step
+                                            p.move(to: CGPoint(x: x, y: 0))
+                                            p.addLine(to: CGPoint(x: x, y: geo.size.height))
+                                        }
                                     }
+                                    .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
                                 }
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- avoid dividing by zero when WeekView has no days

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30bdd3dc8328a7f0779e8993eef7