### PR TITLE
Revamp calendar week view and header

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -14,29 +14,31 @@ public struct CalendarPage: View {
     public var body: some View {
         NavigationView {
             VStack {
-                Picker("", selection: $mode) {
-                    ForEach(Mode.allCases, id: \.self) { Text($0.rawValue).tag($0) }
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal)
+                VStack(spacing: 8) {
+                    Picker("", selection: $mode) {
+                        ForEach(Mode.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal)
 
-                HStack {
-                    Picker("Tag", selection: $selectedTag) {
-                        Text("Tümü").tag(String?.none)
-                        ForEach(Array(Set(store.events.compactMap { $0.tag })), id: \.self) { t in
-                            Text(t).tag(String?.some(t))
+                    HStack {
+                        Picker("Tag", selection: $selectedTag) {
+                            Text("Tümü").tag(String?.none)
+                            ForEach(Array(Set(store.events.compactMap { $0.tag })), id: \.self) { t in
+                                Text(t).tag(String?.some(t))
+                            }
                         }
-                    }
-                    Picker("Proje", selection: $selectedProject) {
-                        Text("Tümü").tag(String?.none)
-                        ForEach(Array(Set(store.events.compactMap { $0.project })), id: \.self) { p in
-                            Text(p).tag(String?.some(p))
+                        Picker("Proje", selection: $selectedProject) {
+                            Text("Tümü").tag(String?.none)
+                            ForEach(Array(Set(store.events.compactMap { $0.project })), id: \.self) { p in
+                                Text(p).tag(String?.some(p))
+                            }
                         }
+                        DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                            .labelsHidden()
                     }
-                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
-                        .labelsHidden()
+                    .padding(.horizontal)
                 }
-                .padding(.horizontal)
 
                 let H: CGFloat = 16
                 if mode == .week {
@@ -62,12 +64,16 @@ public struct CalendarPage: View {
             }
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text("Takvim").font(.headline)
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { Task { await store.syncFromSupabase() } }) {
-                        Image(systemName: "arrow.clockwise")
+                    ZStack {
+                        Text("Takvim").font(.headline)
+                        HStack {
+                            Spacer()
+                            Button(action: { Task { await store.syncFromSupabase() } }) {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                        }
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
             .sheet(isPresented: $showKanban) { KanbanPage() }
@@ -83,83 +89,84 @@ public struct CalendarPage: View {
     }
 }
 
-private struct DayColumn: View {
+private struct DayColumnView: View {
     @EnvironmentObject var store: EventStore
     let day: Date
-    let events: [PlannerEvent]
-    let rowHeight: CGFloat
+    let allEvents: [PlannerEvent]
+    var tag: String?
+    var project: String?
+    let rowHeight: CGFloat = 60
     var body: some View {
-        GeometryReader { geo in
-            let dayWidth = geo.size.width
-            ZStack(alignment: .topLeading) {
-                VStack(spacing: 0) {
-                    ForEach(0..<24, id: \.self) { _ in
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.3))
-                            .frame(height: 0.5)
-                            .offset(y: rowHeight - 0.5)
-                            .frame(height: rowHeight)
-                    }
-                }
-                ForEach(events) { ev in
-                    let y = yOffset(for: ev.start, rowHeight: rowHeight)
-                    let h = height(for: ev, rowHeight: rowHeight)
-                    let durMin = Int(ev.end.timeIntervalSince(ev.start) / 60)
-                    let isSmall = durMin <= 45
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(isSmall ? Theme.accentBG : Theme.secondaryBG)
-                        .overlay(alignment: .topLeading) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(ev.title).font(.caption).bold().foregroundColor(Theme.text)
-                                if let tag = ev.tag, let pr = ev.project {
-                                    Text("\(tag) > \(pr)").font(.system(size: 10)).foregroundColor(Theme.textMuted)
-                                } else if let tag = ev.tag {
-                                    Text(tag).font(.system(size: 10)).foregroundColor(Theme.textMuted)
-                                } else if let pr = ev.project {
-                                    Text(pr).font(.system(size: 10)).foregroundColor(Theme.textMuted)
-                                }
-                            }
-                            .padding(6)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                        }
-                        .frame(height: h)
-                        .offset(y: y)
-                        .zIndex(isSmall ? 1 : 0)
-                        .gesture(dragGesture(for: ev, day: day, rowHeight: rowHeight, dayWidth: dayWidth))
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 0) {
+                ForEach(0..<24, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.3))
+                        .frame(height: 0.5)
+                        .offset(y: rowHeight - 0.5)
+                        .frame(height: rowHeight)
                 }
             }
-            .frame(minHeight: rowHeight * 24, alignment: .top)
+            ForEach(filteredEvents) { ev in
+                let y = yOffset(for: ev.start)
+                let h = height(for: ev)
+                let isSmall = ev.end.timeIntervalSince(ev.start) <= 45*60
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSmall ? Theme.accentBG : Theme.secondaryBG)
+                    .overlay(
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(ev.title).font(.caption).bold().foregroundColor(Theme.text)
+                            if let tag = ev.tag, let pr = ev.project {
+                                Text("\(tag) > \(pr)").font(.system(size: 10)).foregroundColor(Theme.textMuted)
+                            } else if let tag = ev.tag {
+                                Text(tag).font(.system(size: 10)).foregroundColor(Theme.textMuted)
+                            } else if let pr = ev.project {
+                                Text(pr).font(.system(size: 10)).foregroundColor(Theme.textMuted)
+                            }
+                        }
+                        .padding(6)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                    )
+                    .frame(height: h)
+                    .offset(y: y)
+                    .zIndex(isSmall ? 1 : 0)
+                    .gesture(dragGesture15MinSnap(ev))
+            }
+        }
+        .frame(minHeight: rowHeight * 24, alignment: .top)
+    }
+
+    private var filteredEvents: [PlannerEvent] {
+        allEvents.filter { ev in
+            Calendar.current.isDate(ev.start, inSameDayAs: day) &&
+            (tag == nil || ev.tag == tag) &&
+            (project == nil || ev.project == project)
         }
     }
-    private func yOffset(for start: Date, rowHeight: CGFloat) -> CGFloat {
+
+    private func yOffset(for start: Date) -> CGFloat {
         let comps = Calendar.current.dateComponents([.hour, .minute], from: start)
         let h = CGFloat(comps.hour ?? 0)
         let m = CGFloat(comps.minute ?? 0) / 60
         return (h + m) * rowHeight
     }
-    private func height(for ev: PlannerEvent, rowHeight: CGFloat) -> CGFloat {
-        let dur = ev.end.timeIntervalSince(ev.start) / 3600
-        return CGFloat(dur) * rowHeight
+
+    private func height(for ev: PlannerEvent) -> CGFloat {
+        CGFloat(ev.end.timeIntervalSince(ev.start) / 3600) * rowHeight
     }
-    private func snapped(_ date: Date, by minutesDelta: CGFloat) -> Date {
-        let m = Int(minutesDelta.rounded())
-        let snap = (m / 15) * 15
-        return Calendar.current.date(byAdding: .minute, value: snap, to: date)!
-    }
-    private func dragGesture(for ev: PlannerEvent, day: Date, rowHeight: CGFloat, dayWidth: CGFloat) -> some Gesture {
+
+    private func dragGesture15MinSnap(_ ev: PlannerEvent) -> some Gesture {
         DragGesture()
             .onEnded { value in
                 let minutes = (value.translation.height / rowHeight) * 60.0
-                let dayShift = Int((value.translation.width / dayWidth).rounded())
-                var newStart = snapped(ev.start, by: minutes)
-                var newEnd = snapped(ev.end, by: minutes)
-                if dayShift != 0 {
-                    newStart = Calendar.current.date(byAdding: .day, value: dayShift, to: newStart) ?? newStart
-                    newEnd = Calendar.current.date(byAdding: .day, value: dayShift, to: newEnd) ?? newEnd
+                func snap(_ d: Date) -> Date {
+                    let m = Int(minutes.rounded())
+                    let s = (m / 15) * 15
+                    return Calendar.current.date(byAdding: .minute, value: s, to: d)!
                 }
                 if let idx = store.events.firstIndex(where: { $0.id == ev.id }) {
-                    store.events[idx].start = newStart
-                    store.events[idx].end = newEnd
+                    store.events[idx].start = snap(ev.start)
+                    store.events[idx].end = snap(ev.end)
                     store.save()
                     Task { await store.backupToSupabase() }
                 }
@@ -171,122 +178,111 @@ private struct DayTimelineView: View {
     @EnvironmentObject var store: EventStore
     var date: Date
     var events: [PlannerEvent]
-    let rowHeight: CGFloat = 60
+    private let hoursWidth: CGFloat = 44
+    private let rowHeight: CGFloat = 60
     var body: some View {
-        ScrollView {
-            HStack(alignment: .top, spacing: 0) {
+        ScrollView(.vertical) {
+            ZStack(alignment: .topLeading) {
                 VStack(spacing: 0) {
                     ForEach(0..<24, id: \.self) { hr in
                         Text("\(hr):00")
-                            .frame(width: 40, height: rowHeight, alignment: .topLeading)
                             .foregroundColor(Theme.text)
                             .font(.caption)
+                            .frame(width: hoursWidth, height: rowHeight, alignment: .topLeading)
+                            .border(Color.gray.opacity(0.3), width: 0.5)
                     }
                 }
-                DayColumn(day: date, events: events, rowHeight: rowHeight)
-                    .frame(maxWidth: .infinity)
+                .frame(width: hoursWidth)
+                .allowsHitTesting(false)
+
+                DayColumnView(day: date, allEvents: events, tag: nil, project: nil)
+                    .padding(.leading, hoursWidth)
             }
         }
     }
 }
 
 private struct WeekView: View {
-    @EnvironmentObject var store: EventStore
     @Binding var selectedDate: Date
     var events: [PlannerEvent]
     var tag: String?
     var project: String?
-    let rowHeight: CGFloat = 60
-    private let dayFormatter: DateFormatter = {
-        let f = DateFormatter(); f.dateFormat = "E dd"; return f
-    }()
-    @State private var days: [Date] = []
-    private let headerHeight: CGFloat = 24
+    @State private var anchor: Int = 0
+    @State private var scrollPosition: Int = 0
+    private let hoursWidth: CGFloat = 44
+    private let rowHeight: CGFloat = 60
+    private let ref = Calendar.current.startOfDay(for: Date())
 
     var body: some View {
-        ScrollView(.vertical) {
-            HStack(alignment: .top, spacing: 0) {
-                VStack(spacing: 0) {
-                    Text("")
-                        .frame(width: 40, height: headerHeight)
-                    ForEach(0..<24, id: \.self) { hr in
-                        Text("\(hr):00")
-                            .frame(width: 40, height: rowHeight, alignment: .topLeading)
+        GeometryReader { geo in
+            let dayWidth = (geo.size.width - hoursWidth) / 3
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    Color.clear.frame(width: hoursWidth)
+                    ForEach(0..<3, id: \.self) { i in
+                        let d = dateFor(index: anchor - (2 - i))
+                        Text(dayLabel(d))
+                            .frame(width: dayWidth)
                             .foregroundColor(Theme.text)
-                            .font(.caption)
                     }
                 }
-                ScrollView(.horizontal, showsIndicators: false) {
-                    VStack(spacing: 0) {
-                        HStack(spacing: 0) {
-                            ForEach(days.indices, id: \.self) { idx in
-                                let day = days[idx]
-                                Text(dayFormatter.string(from: day))
-                                    .frame(width: 100, height: headerHeight)
+                .padding(.vertical, 4)
+
+                ScrollView(.vertical) {
+                    ZStack(alignment: .topLeading) {
+                        VStack(spacing: 0) {
+                            ForEach(0..<24, id: \.self) { hr in
+                                Text("\(hr):00")
                                     .foregroundColor(Theme.text)
-                                    .onAppear {
-                                        if idx == days.count - 1 { appendDays() }
-                                        if idx == 0 { prependDays() }
-                                    }
+                                    .font(.caption)
+                                    .frame(width: hoursWidth, height: rowHeight, alignment: .topLeading)
+                                    .border(Color.gray.opacity(0.3), width: 0.5)
                             }
                         }
-                        HStack(alignment: .top, spacing: 0) {
-                            ForEach(days.indices, id: \.self) { idx in
-                                let day = days[idx]
-                                DayColumn(day: day,
-                                          events: eventsFor(day: day),
-                                          rowHeight: rowHeight)
-                                    .frame(width: 100)
-                            }
-                        }
-                        .overlay(alignment: .topLeading) {
-                            if !days.isEmpty {
-                                GeometryReader { geo in
-                                    let w = geo.size.width
-                                    let colCount = Double(days.count)
-                                    let step = w / colCount
-                                    Path { p in
-                                        for i in 1..<Int(colCount) {
-                                            let x = CGFloat(i) * step
-                                            p.move(to: CGPoint(x: x, y: 0))
-                                            p.addLine(to: CGPoint(x: x, y: geo.size.height))
-                                        }
-                                    }
-                                    .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
+                        .frame(width: hoursWidth)
+                        .allowsHitTesting(false)
+
+                        ScrollView(.horizontal) {
+                            LazyHStack(spacing: 0) {
+                                ForEach(-20000...20000, id: \.self) { idx in
+                                    DayColumnView(day: dateFor(index: idx), allEvents: events, tag: tag, project: project)
+                                        .frame(width: dayWidth)
+                                        .border(Color.gray.opacity(0.3), width: 0.5)
                                 }
                             }
+                            .scrollTargetLayout()
                         }
+                        .scrollIndicators(.hidden)
+                        .scrollTargetBehavior(.viewAligned)
+                        .scrollPosition(id: $scrollPosition)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, hoursWidth)
                     }
                 }
             }
+            .onAppear {
+                anchor = daysBetween(ref, selectedDate)
+                scrollPosition = anchor - 2
+            }
+            .onChange(of: selectedDate) { new in
+                anchor = daysBetween(ref, new)
+                scrollPosition = anchor - 2
+            }
         }
-        .onAppear { initializeDays() }
     }
 
-    private func initializeDays() {
-        days = (-3...3).compactMap { Calendar.current.date(byAdding: .day, value: $0, to: selectedDate) }
+    private func dayLabel(_ d: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "E dd"
+        return f.string(from: d)
     }
-    private func appendDays() {
-        guard let last = days.last else { return }
-        for i in 1...3 {
-            if let newDay = Calendar.current.date(byAdding: .day, value: i, to: last) {
-                days.append(newDay)
-            }
-        }
+    private func daysBetween(_ a: Date, _ b: Date) -> Int {
+        let cal = Calendar.current
+        let startA = cal.startOfDay(for: a)
+        let startB = cal.startOfDay(for: b)
+        return cal.dateComponents([.day], from: startA, to: startB).day ?? 0
     }
-    private func prependDays() {
-        guard let first = days.first else { return }
-        for i in 1...3 {
-            if let newDay = Calendar.current.date(byAdding: .day, value: -i, to: first) {
-                days.insert(newDay, at: 0)
-            }
-        }
-    }
-    private func eventsFor(day: Date) -> [PlannerEvent] {
-        events.filter { ev in
-            Calendar.current.isDate(ev.start, inSameDayAs: day) &&
-            (tag == nil || ev.tag == tag) &&
-            (project == nil || ev.project == project)
-        }
+    private func dateFor(index: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: index, to: ref)!
     }
 }


### PR DESCRIPTION
## Summary
- center calendar title with embedded refresh control
- streamline picker and filter spacing
- rebuild week view with lazy day-by-day scrolling and draggable event blocks

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aa324fef0c83288d150affb6290266