### PR TITLE
Fix scrollPosition binding type in CalendarPage

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -208,7 +208,7 @@ private struct WeekView: View {
     var tag: String?
     var project: String?
     @State private var anchor: Int = 0
-    @State private var scrollPosition: Int = 0
+    @State private var scrollPosition: Int? = 0
     private let hoursWidth: CGFloat = 44
     private let rowHeight: CGFloat = 60
     private let ref = Calendar.current.startOfDay(for: Date())


### PR DESCRIPTION
## Summary
- fix compile error by making scrollPosition optional Int for SwiftUI scrollPosition binding

## Testing
- `swiftc -parse ios/Views/Calendar/CalendarPage.swift`


------
https://chatgpt.com/codex/tasks/task_e_68aa34c71650832898edd3fe1af0bf2d