### PR TITLE
Fix missing binding type annotation in CalendarPage

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -100,7 +100,7 @@ private struct DayColumnView: View {
     var project: String?
     var dayWidth: CGFloat? = nil
     let rowHeight: CGFloat
-    @Binding var isDragging
+    @Binding var isDragging: Bool
     private var onePx: CGFloat { 1 / scale }
     var body: some View {
         ZStack(alignment: .topLeading) {


### PR DESCRIPTION
## Summary
- fix compile error by adding `Bool` type annotation to `isDragging` binding in `DayColumnView`

## Testing
- `swiftc ios/Views/Calendar/CalendarPage.swift -typecheck` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c85d92c83288e51eedc2cc4d92e