### PR TITLE
Use primary background for top tasks and remove accent border

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -41,7 +41,7 @@ public struct CalendarPage: View {
                 .background(Theme.primaryBG)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(Theme.accent, lineWidth: 1)
+                        .stroke(Theme.secondaryBG, lineWidth: 1)
                 )
                 .padding(.horizontal)
                 .padding(.top, 2)
@@ -127,7 +127,7 @@ private struct DayColumnView: View {
                 let isDraggedEvent = draggedEventId == ev.id || resizingEventId == ev.id
 
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(isSmall ? Theme.accentBG : Theme.secondaryBG)
+                    .fill(isSmall ? Theme.primaryBG : Theme.secondaryBG)
                     .overlay(alignment: .topLeading) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(ev.title).font(.caption).bold().foregroundColor(Theme.text)


### PR DESCRIPTION
## Summary
- Use primary background instead of accent color for the topmost overlapping task card.
- Replace accent-colored border around the day/week mode picker with a neutral secondary background stroke.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b95af1483288a0a0d631293d8b0