### PR TITLE
Fix Kanban onDrop trailing closure compile error

### DIFF
--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -45,9 +45,7 @@ private struct KanbanColumn: View {
                         .onDrag { NSItemProvider(object: String(task.id) as NSString) }
                 }
             }
-            .onDrop(of: [.text]) { providers in
-                handleDrop(providers)
-            }
+            .onDrop(of: [.text], isTargeted: nil, perform: handleDrop)
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Fix `.onDrop` call in Kanban column to specify `isTargeted` and forward `handleDrop`

## Testing
- `swiftc ios/Views/Kanban/KanbanPage.swift -typecheck` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aa6899f2fc8328a40031d849107e8c