### PR TITLE
Replace Supabase tasks on refresh and fix Kanban column layout

### DIFF
--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -117,6 +117,15 @@ public final class SupabaseService {
             _ = try await URLSession.shared.data(for: req)
         }
     }
+    public func deleteAllTasks() async throws {
+        if let req = request(path: "tasks?id=gt.0", method: "DELETE") {
+            _ = try await URLSession.shared.data(for: req)
+        }
+    }
+    public func replaceTasks(_ items: [PlannerTask]) async throws {
+        try await deleteAllTasks()
+        try await upsertTasks(items)
+    }
     public func uploadWeeklyEnergy(userId: String, items: [DayEnergy]) async {
         let rows: [[String: Any]] = items.map { [
             "user_id": userId,

--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -33,4 +33,7 @@ public final class TaskStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertTasks(tasks)
     }
+    public func replaceSupabaseWithLocal() async {
+        try? await SupabaseService.shared.replaceTasks(tasks)
+    }
 }

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -39,12 +39,18 @@ private struct KanbanColumn: View {
             Text(title)
                 .foregroundColor(Theme.text)
                 .font(.headline)
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(tasks) { task in
-                    TaskCard(task: task)
-                        .onDrag { NSItemProvider(object: String(task.id) as NSString) }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(tasks) { task in
+                        TaskCard(task: task)
+                            .onDrag { NSItemProvider(object: String(task.id) as NSString) }
+                    }
                 }
+                .padding(8)
             }
+            .frame(height: 200)
+            .background(Theme.secondaryBG)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
             .onDrop(of: [.text], delegate: DropHandler(onDropTask: onDropTask))
         }
         .padding()
@@ -88,7 +94,7 @@ public struct KanbanPage: View {
             }
             .scrollIndicators(.hidden)
             .refreshable {
-                await store.backupToSupabase()
+                await store.replaceSupabaseWithLocal()
                 await store.syncFromSupabase()
             }
 


### PR DESCRIPTION
## Summary
- Add ability to delete all remote tasks and replace them with local tasks
- Add TaskStore helper to push local tasks replacing remote data
- Wrap Kanban columns in fixed-size scrollable boxes and refresh pushes local data first

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa6c5123b483288e9903c060375599