### PR TITLE
Integrate kanban backup with calendar refresh

### DIFF
--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -74,8 +74,8 @@ private struct KanbanColumn: View {
 }
 
 public struct KanbanPage: View {
-    @StateObject private var store = TaskStore()
-    public init() {}
+    @ObservedObject var store: TaskStore
+    public init(store: TaskStore) { self.store = store }
     public var body: some View {
         VStack {
             ScrollView {
@@ -93,10 +93,6 @@ public struct KanbanPage: View {
                 .padding(.horizontal)
             }
             .scrollIndicators(.hidden)
-            .refreshable {
-                await store.replaceSupabaseWithLocal()
-                await store.syncFromSupabase()
-            }
 
             Button(action: {
                 // TODO: Görev ekleme


### PR DESCRIPTION
## Summary
- remove swipe refresh from Kanban board and share TaskStore
- extend calendar refresh to sync tasks and events

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc -typecheck ios/Views/Kanban/KanbanPage.swift ios/Services/TaskStore.swift ios/Services/EventStore.swift ios/Views/Calendar/CalendarPage.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aa6ee659ac8328a87e0471b3bb522c