### PR TITLE
fix: sync calendar updates

### DIFF
--- a/ios/Services/EventStore.swift
+++ b/ios/Services/EventStore.swift
@@ -47,4 +47,7 @@ public final class EventStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertEvents(events)
     }
+    public func replaceSupabaseWithLocal() async {
+        try? await SupabaseService.shared.replaceEvents(events)
+    }
 }

--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -118,13 +118,23 @@ public final class SupabaseService {
         }
     }
     public func deleteAllTasks() async throws {
-        if let req = request(path: "tasks?id=gt.0", method: "DELETE") {
+        let filter = "or=(has_time.eq.false,and(has_time.is.null,start_ts.is.null))"
+        if let req = request(path: "tasks?\(filter)", method: "DELETE") {
             _ = try await URLSession.shared.data(for: req)
         }
     }
     public func replaceTasks(_ items: [PlannerTask]) async throws {
         try await deleteAllTasks()
         try await upsertTasks(items)
+    }
+    public func deleteAllEvents() async throws {
+        if let req = request(path: "tasks?has_time=eq.true", method: "DELETE") {
+            _ = try await URLSession.shared.data(for: req)
+        }
+    }
+    public func replaceEvents(_ items: [PlannerEvent]) async throws {
+        try await deleteAllEvents()
+        try await upsertEvents(items)
     }
     public func uploadWeeklyEnergy(userId: String, items: [DayEnergy]) async {
         let rows: [[String: Any]] = items.map { [

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -67,18 +67,19 @@ public struct CalendarPage: View {
                     ZStack {
                         Text("Takvim").font(.headline)
                         HStack {
-                            Button("Kanban") { showKanban = true }
-                            Spacer()
-                            Button(action: {
-                                Task {
-                                    await taskStore.replaceSupabaseWithLocal()
-                                    await taskStore.syncFromSupabase()
-                                    await store.syncFromSupabase()
-                                }
-                            }) {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                        }
+                              Button("Kanban") { showKanban = true }
+                              Spacer()
+                              Button(action: {
+                                  Task {
+                                      await taskStore.replaceSupabaseWithLocal()
+                                      await store.replaceSupabaseWithLocal()
+                                      await taskStore.syncFromSupabase()
+                                      await store.syncFromSupabase()
+                                  }
+                              }) {
+                                  Image(systemName: "arrow.clockwise")
+                              }
+                          }
                     }
                     .frame(maxWidth: .infinity)
                 }


### PR DESCRIPTION
## Summary
- ensure refresh also updates calendar events on Supabase
- add event replace helpers in Supabase service and store
- avoid wiping events when replacing tasks

## Testing
- `swiftc -typecheck ios/Services/EventStore.swift ios/Services/SupabaseService.swift ios/Services/TaskStore.swift ios/Views/Calendar/CalendarPage.swift ios/Models/Event.swift ios/Models/Task.swift ios/Models/Models.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aa70c178d08328b399488033c75b97