### PR TITLE
Fix task metadata loss on iOS upsert

### DIFF
--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -17,7 +17,7 @@ public final class SupabaseService {
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("Bearer \(SupabaseConfig.anonKey)", forHTTPHeaderField: "Authorization")
         req.setValue(SupabaseConfig.anonKey, forHTTPHeaderField: "apikey")
-        req.setValue("return=minimal", forHTTPHeaderField: "Prefer")
+        req.setValue("return=minimal,resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
         req.httpBody = body
         return req
     }


### PR DESCRIPTION
## Summary
- ensure Supabase upserts merge with existing rows to preserve fields like due date, tag and project

## Testing
- `swiftc ios/Services/SupabaseService.swift -parse`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aaedbcbb5883288b88045044726d07