### PR TITLE
Fix task metadata being wiped on iOS edits

### DIFF
--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -4,17 +4,26 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
     public var id: Int
     public var title: String
     public var status: String?
+    public var tagId: Int?
     public var tag: String?
+    public var projectId: Int?
     public var project: String?
+    public var due: Date?
     public init(id: Int = Int(Date().timeIntervalSince1970),
                 title: String,
                 status: String? = nil,
+                tagId: Int? = nil,
                 tag: String? = nil,
-                project: String? = nil) {
+                projectId: Int? = nil,
+                project: String? = nil,
+                due: Date? = nil) {
         self.id = id
         self.title = title
         self.status = status
+        self.tagId = tagId
         self.tag = tag
+        self.projectId = projectId
         self.project = project
+        self.due = due
     }
 }


### PR DESCRIPTION
## Summary
- track tag/project IDs and due date in `PlannerTask`
- include tag, project and due date when syncing tasks with Supabase

## Testing
- `swiftc -typecheck ios/Models/Task.swift`
- `swiftc -typecheck ios/Services/SupabaseService.swift ios/Models/Task.swift ios/Models/Event.swift ios/Models/Models.swift` *(fails: no such module 'HealthKit')*


------
https://chatgpt.com/codex/tasks/task_e_68aaf2864fb48328a4d40e3069e51580