### PR TITLE
Store full planner data and expose all tags

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -6,21 +6,30 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
     public var start: Date
     public var end: Date
     public var status: String?
+    public var notes: String?
+    public var tagId: Int?
     public var tag: String?
+    public var projectId: Int?
     public var project: String?
     public init(id: Int = Int(Date().timeIntervalSince1970),
                 title: String,
                 start: Date,
                 end: Date,
                 status: String? = nil,
+                notes: String? = nil,
+                tagId: Int? = nil,
                 tag: String? = nil,
+                projectId: Int? = nil,
                 project: String? = nil) {
         self.id = id
         self.title = title
         self.start = start
         self.end = end
         self.status = status
+        self.notes = notes
+        self.tagId = tagId
         self.tag = tag
+        self.projectId = projectId
         self.project = project
     }
 }

--- a/ios/Models/Project.swift
+++ b/ios/Models/Project.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct PlannerProject: Identifiable, Codable, Hashable {
+    public var id: Int
+    public var name: String
+    public var tagId: Int?
+    public var createdAt: Date?
+    public var updatedAt: Date?
+    public init(id: Int, name: String, tagId: Int? = nil, createdAt: Date? = nil, updatedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.tagId = tagId
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case tagId = "tag_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}

--- a/ios/Models/Tag.swift
+++ b/ios/Models/Tag.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct PlannerTag: Identifiable, Codable, Hashable {
+    public var id: Int
+    public var name: String
+    public var createdAt: Date?
+    public var updatedAt: Date?
+    public init(id: Int, name: String, createdAt: Date? = nil, updatedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}

--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -3,27 +3,39 @@ import Foundation
 public struct PlannerTask: Identifiable, Codable, Hashable {
     public var id: Int
     public var title: String
+    public var notes: String?
     public var status: String?
     public var tagId: Int?
     public var tag: String?
     public var projectId: Int?
     public var project: String?
     public var due: Date?
+    public var start: Date?
+    public var end: Date?
+    public var hasTime: Bool?
     public init(id: Int = Int(Date().timeIntervalSince1970),
                 title: String,
+                notes: String? = nil,
                 status: String? = nil,
                 tagId: Int? = nil,
                 tag: String? = nil,
                 projectId: Int? = nil,
                 project: String? = nil,
-                due: Date? = nil) {
+                due: Date? = nil,
+                start: Date? = nil,
+                end: Date? = nil,
+                hasTime: Bool? = nil) {
         self.id = id
         self.title = title
+        self.notes = notes
         self.status = status
         self.tagId = tagId
         self.tag = tag
         self.projectId = projectId
         self.project = project
         self.due = due
+        self.start = start
+        self.end = end
+        self.hasTime = hasTime
     }
 }

--- a/ios/Services/ProjectStore.swift
+++ b/ios/Services/ProjectStore.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+public final class ProjectStore: ObservableObject {
+    @Published public var projects: [PlannerProject] = []
+    private let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("projects.json")
+    }()
+    public init() { load() }
+
+    public func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([PlannerProject].self, from: data) {
+            projects = decoded
+        }
+    }
+
+    public func save() {
+        if let data = try? JSONEncoder().encode(projects) {
+            try? data.write(to: fileURL)
+        }
+    }
+
+    public func syncFromSupabase() async {
+        if let remote = try? await SupabaseService.shared.fetchProjects() {
+            DispatchQueue.main.async {
+                self.projects = remote
+                self.save()
+            }
+        }
+    }
+}

--- a/ios/Services/TagStore.swift
+++ b/ios/Services/TagStore.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+public final class TagStore: ObservableObject {
+    @Published public var tags: [PlannerTag] = []
+    private let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("tags.json")
+    }()
+    public init() { load() }
+
+    public func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([PlannerTag].self, from: data) {
+            tags = decoded
+        }
+    }
+
+    public func save() {
+        if let data = try? JSONEncoder().encode(tags) {
+            try? data.write(to: fileURL)
+        }
+    }
+
+    public func syncFromSupabase() async {
+        if let remote = try? await SupabaseService.shared.fetchTags() {
+            DispatchQueue.main.async {
+                self.tags = remote
+                self.save()
+            }
+        }
+    }
+}

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -3,6 +3,8 @@ import SwiftUI
 public struct CalendarPage: View {
     @StateObject private var store = EventStore()
     @StateObject private var taskStore = TaskStore()
+    @StateObject private var tagStore = TagStore()
+    @StateObject private var projectStore = ProjectStore()
     @State private var selectedDate = Date()
     @State private var showKanban = false
     @State private var mode: Mode = .week
@@ -24,14 +26,14 @@ public struct CalendarPage: View {
                     HStack {
                         Picker("Tag", selection: $selectedTag) {
                             Text("Tümü").tag(String?.none)
-                            ForEach(Array(Set(store.events.compactMap { $0.tag })), id: \.self) { t in
-                                Text(t).tag(String?.some(t))
+                            ForEach(tagStore.tags, id: \.id) { t in
+                                Text(t.name).tag(String?.some(t.name))
                             }
                         }
                         Picker("Proje", selection: $selectedProject) {
                             Text("Tümü").tag(String?.none)
-                            ForEach(Array(Set(store.events.compactMap { $0.project })), id: \.self) { p in
-                                Text(p).tag(String?.some(p))
+                            ForEach(projectStore.projects, id: \.id) { p in
+                                Text(p.name).tag(String?.some(p.name))
                             }
                         }
                         DatePicker("", selection: $selectedDate, displayedComponents: .date)
@@ -88,6 +90,8 @@ public struct CalendarPage: View {
             .task {
                 await taskStore.syncFromSupabase()
                 await store.syncFromSupabase()
+                await tagStore.syncFromSupabase()
+                await projectStore.syncFromSupabase()
             }
             .background(Theme.primaryBG.ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- add Tag and Project models plus SwiftUI stores for local persistence
- expand task/event models and Supabase service to include all task attributes
- populate calendar tag/project pickers from full tag and project lists

## Testing
- `swiftc -typecheck ios/Models/Tag.swift ios/Models/Project.swift ios/Models/Task.swift ios/Models/Event.swift ios/Services/TagStore.swift ios/Services/ProjectStore.swift ios/Services/SupabaseService.swift ios/Services/EventStore.swift ios/Services/TaskStore.swift ios/Views/Kanban/KanbanPage.swift ios/Views/Calendar/CalendarPage.swift` *(fails: no such module 'SwiftUI')*
- `swiftc -typecheck ios/Models/Tag.swift ios/Models/Project.swift ios/Models/Task.swift ios/Models/Event.swift /tmp/DayEnergy.swift ios/Services/SupabaseService.swift`


------
https://chatgpt.com/codex/tasks/task_e_68aaf5a7314883288857fc0bd028722d