### PR TITLE
Use unique millisecond IDs and avoid destructive remote replace

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -11,7 +11,12 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
     public var tag: String?
     public var projectId: Int?
     public var project: String?
-    public init(id: Int = Int(Date().timeIntervalSince1970),
+    private static func makeId() -> Int {
+        let ms = Int(Date().timeIntervalSince1970 * 1000)
+        let rand = Int.random(in: 0..<1000)
+        return ms * 1000 + rand
+    }
+    public init(id: Int = Self.makeId(),
                 title: String,
                 start: Date,
                 end: Date,

--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -13,7 +13,12 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
     public var start: Date?
     public var end: Date?
     public var hasTime: Bool?
-    public init(id: Int = Int(Date().timeIntervalSince1970),
+    private static func makeId() -> Int {
+        let ms = Int(Date().timeIntervalSince1970 * 1000)
+        let rand = Int.random(in: 0..<1000)
+        return ms * 1000 + rand
+    }
+    public init(id: Int = Self.makeId(),
                 title: String,
                 notes: String? = nil,
                 status: String? = nil,

--- a/ios/Services/EventStore.swift
+++ b/ios/Services/EventStore.swift
@@ -47,7 +47,4 @@ public final class EventStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertEvents(events)
     }
-    public func replaceSupabaseWithLocal() async {
-        try? await SupabaseService.shared.replaceEvents(events)
-    }
 }

--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -33,7 +33,4 @@ public final class TaskStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertTasks(tasks)
     }
-    public func replaceSupabaseWithLocal() async {
-        try? await SupabaseService.shared.replaceTasks(tasks)
-    }
 }

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -73,8 +73,8 @@ public struct CalendarPage: View {
                               Spacer()
                               Button(action: {
                                   Task {
-                                      await taskStore.replaceSupabaseWithLocal()
-                                      await store.replaceSupabaseWithLocal()
+                                      await taskStore.backupToSupabase()
+                                      await store.backupToSupabase()
                                       await taskStore.syncFromSupabase()
                                       await store.syncFromSupabase()
                                   }


### PR DESCRIPTION
## Summary
- Generate task and event IDs with millisecond precision plus a random suffix to avoid collisions
- Remove destructive replace-supabase methods and use non-destructive backup from the calendar toolbar

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aafeaa15008328b4501f603aab5f64