### PR TITLE
Fix PlannerEvent ID generation visibility issue

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -16,7 +16,7 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
         let rand = Int.random(in: 0..<1000)
         return ms * 1000 + rand
     }
-    public init(id: Int = Self.makeId(),
+    public init(id: Int? = nil,
                 title: String,
                 start: Date,
                 end: Date,
@@ -26,7 +26,7 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
                 tag: String? = nil,
                 projectId: Int? = nil,
                 project: String? = nil) {
-        self.id = id
+        self.id = id ?? Self.makeId()
         self.title = title
         self.start = start
         self.end = end


### PR DESCRIPTION
## Summary
- Generate a PlannerEvent ID inside initializer instead of using a private method as a default argument

## Testing
- `swiftc -typecheck ios/Models/Event.swift && echo 'typecheck passed'`


------
https://chatgpt.com/codex/tasks/task_e_68ab005381f883289e22c17deb302ce1