### PR TITLE
Fix ID generation in Planner models

### DIFF
--- a/ios/Models/Event.swift
+++ b/ios/Models/Event.swift
@@ -19,7 +19,7 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
     public var project: String?
 
     public init(
-        id: Int = makeId(),
+        id: Int? = nil,
         title: String,
         start: Date,
         end: Date,
@@ -30,7 +30,7 @@ public struct PlannerEvent: Identifiable, Codable, Hashable {
         projectId: Int? = nil,
         project: String? = nil
     ) {
-        self.id = id
+        self.id = id ?? makeId()
         self.title = title
         self.start = start
         self.end = end

--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -20,7 +20,7 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
     public var end: Date?
     public var hasTime: Bool?
     public init(
-        id: Int = makeId(),
+        id: Int? = nil,
         title: String,
         notes: String? = nil,
         status: String? = nil,
@@ -33,7 +33,7 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
         end: Date? = nil,
         hasTime: Bool? = nil
     ) {
-        self.id = id
+        self.id = id ?? makeId()
         self.title = title
         self.notes = notes
         self.status = status


### PR DESCRIPTION
## Summary
- avoid referencing private `makeId()` in default parameters by generating IDs inside initializers for events and tasks

## Testing
- `swiftc ios/Models/Event.swift ios/Models/Task.swift -typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b35fe5c832886d5e84c1ffdc93a