### PR TITLE
Improve calendar refresh and Kanban task metadata

### DIFF
--- a/ios/Models/Task.swift
+++ b/ios/Models/Task.swift
@@ -15,6 +15,8 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
     public var tag: String?
     public var projectId: Int?
     public var project: String?
+    public var parentId: Int?
+    public var parent: String?
     public var due: Date?
     public var start: Date?
     public var end: Date?
@@ -28,6 +30,8 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
         tag: String? = nil,
         projectId: Int? = nil,
         project: String? = nil,
+        parentId: Int? = nil,
+        parent: String? = nil,
         due: Date? = nil,
         start: Date? = nil,
         end: Date? = nil,
@@ -41,6 +45,8 @@ public struct PlannerTask: Identifiable, Codable, Hashable {
         self.tag = tag
         self.projectId = projectId
         self.project = project
+        self.parentId = parentId
+        self.parent = parent
         self.due = due
         self.start = start
         self.end = end

--- a/ios/Services/SupabaseService.swift
+++ b/ios/Services/SupabaseService.swift
@@ -147,7 +147,7 @@ public final class SupabaseService {
 
     // MARK: Tasks
     public func fetchTasks() async throws -> [PlannerTask] {
-        let fields = "id,title,notes,status,tag_id,tag:tags(name),project_id,project:projects(name),has_time,due_date,start_ts,end_ts"
+        let fields = "id,title,notes,status,tag_id,tag:tags(name),project_id,project:projects(name),parent_id,parent:tasks!tasks_parent_id_fkey(title),has_time,due_date,start_ts,end_ts"
         let filter = "or=(has_time.eq.false,and(has_time.is.null,start_ts.is.null))"
         let path = "tasks?select=\(fields)&\(filter)"
         guard let req = request(path: path, method: "GET") else { return [] }
@@ -162,6 +162,8 @@ public final class SupabaseService {
             let tag: NameHolder?
             let project_id: Int?
             let project: NameHolder?
+            let parent_id: Int?
+            let parent: NameHolder?
             let has_time: Bool?
             let due_date: String?
             let start_ts: Date?
@@ -180,6 +182,8 @@ public final class SupabaseService {
                                tag: r.tag?.name,
                                projectId: r.project_id,
                                project: r.project?.name,
+                               parentId: r.parent_id,
+                               parent: r.parent?.name,
                                due: due,
                                start: r.start_ts,
                                end: r.end_ts,
@@ -195,6 +199,7 @@ public final class SupabaseService {
             var has_time: Bool
             var tag_id: Int?
             var project_id: Int?
+            var parent_id: Int?
             var due_date: String?
             var start_ts: Date?
             var end_ts: Date?
@@ -208,6 +213,7 @@ public final class SupabaseService {
                        has_time: t.hasTime ?? false,
                        tag_id: t.tagId,
                        project_id: t.projectId,
+                       parent_id: t.parentId,
                        due_date: t.due.map { df.string(from: $0) },
                        start_ts: t.start,
                        end_ts: t.end)

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -75,8 +75,12 @@ public struct CalendarPage: View {
                                   Task {
                                       await taskStore.backupToSupabase()
                                       await store.backupToSupabase()
+                                      await tagStore.backupToSupabase()
+                                      await projectStore.backupToSupabase()
                                       await taskStore.syncFromSupabase()
                                       await store.syncFromSupabase()
+                                      await tagStore.syncFromSupabase()
+                                      await projectStore.syncFromSupabase()
                                   }
                               }) {
                                   Image(systemName: "arrow.clockwise")

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -3,29 +3,34 @@ import UniformTypeIdentifiers
 
 private struct TaskCard: View {
     var task: PlannerTask
+    private static let df: DateFormatter = {
+        let d = DateFormatter()
+        d.dateStyle = .short
+        return d
+    }()
     var body: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(task.title)
-                    .foregroundColor(Theme.text)
-                if let meta = metaText {
-                    Text(meta)
-                        .font(.footnote)
-                        .foregroundColor(Theme.textMuted)
-                }
-            }
+            Text(titleWithMeta)
+                .foregroundColor(Theme.text)
             Spacer()
+            if let due = task.due {
+                Text(Self.df.string(from: due))
+                    .font(.footnote)
+                    .foregroundColor(Theme.textMuted)
+            }
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.secondaryBG)
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
-    private var metaText: String? {
+    private var titleWithMeta: String {
         var parts: [String] = []
         if let tag = task.tag { parts.append(tag) }
         if let project = task.project { parts.append(project) }
-        return parts.isEmpty ? nil : parts.joined(separator: " > ")
+        if let parent = task.parent { parts.append(parent) }
+        let meta = parts.isEmpty ? "" : " (" + parts.joined(separator: " > ") + ")"
+        return task.title + meta
     }
 }
 


### PR DESCRIPTION
## Summary
- show task tag, project, and parent in Kanban cards along with due date
- include parent info for tasks and sync it via Supabase
- refresh button also syncs tags and projects for up-to-date filters

## Testing
- `swiftc -typecheck ios/Models/Task.swift`
- `swiftc -typecheck ios/Views/Kanban/KanbanPage.swift ios/Models/Task.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d5081508328ad09bf63fb4bab71