### PR TITLE
Add local DB sync control and Kanban styling tweaks

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -69,8 +69,23 @@ public struct CalendarPage: View {
                     ZStack {
                         Text("Takvim").font(.headline)
                         HStack {
-                              Button("Kanban") { showKanban = true }
+                              Button(action: { showKanban = true }) {
+                                  Image(systemName: "square.grid.2x2")
+                              }
                               Spacer()
+                              Button(action: {
+                                  Task {
+                                      await SyncOrchestrator.initialPull(tags: tagStore,
+                                                                         projects: projectStore,
+                                                                         tasks: taskStore,
+                                                                         events: store)
+                                      let vm = HealthDashboardVM(weightStore: WeightStore())
+                                      await vm.requestAuth()
+                                      await vm.refresh()
+                                  }
+                              }) {
+                                  Image(systemName: "arrow.down.circle")
+                              }
                               Button(action: {
                                   Task {
                                       await taskStore.backupToSupabase()

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -10,13 +10,19 @@ private struct TaskCard: View {
     }()
     var body: some View {
         HStack {
-            Text(titleWithMeta)
-                .foregroundColor(Theme.text)
+            HStack(spacing: 0) {
+                Text(task.title)
+                    .foregroundColor(Theme.text)
+                if let meta = metaText {
+                    Text(" (\(meta))")
+                        .foregroundColor(Theme.textMuted)
+                }
+            }
             Spacer()
             if let due = task.due {
                 Text(Self.df.string(from: due))
                     .font(.footnote)
-                    .foregroundColor(Theme.textMuted)
+                    .foregroundColor(Theme.text)
             }
         }
         .padding(8)
@@ -24,13 +30,12 @@ private struct TaskCard: View {
         .background(Theme.secondaryBG)
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
-    private var titleWithMeta: String {
+    private var metaText: String? {
         var parts: [String] = []
         if let tag = task.tag { parts.append(tag) }
         if let project = task.project { parts.append(project) }
         if let parent = task.parent { parts.append(parent) }
-        let meta = parts.isEmpty ? "" : " (" + parts.joined(separator: " > ") + ")"
-        return task.title + meta
+        return parts.isEmpty ? nil : parts.joined(separator: " > ")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add icon buttons for Kanban, local DB sync, and refresh in the calendar toolbar
- Sync local data from Supabase and pull health data via the new update button
- Soften Kanban metadata color and display due dates in white

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab121105b4832898270b282c1663b5