### PR TITLE
Fix calendar sync order for Supabase backup

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -88,14 +88,16 @@ public struct CalendarPage: View {
                               }
                               Button(action: {
                                   Task {
-                                      await taskStore.backupToSupabase()
-                                      await store.backupToSupabase()
+                                      // Foreign key bütünlüğü için önce tag ve projeler, sonra görevler ve etkinlikler
                                       await tagStore.backupToSupabase()
                                       await projectStore.backupToSupabase()
-                                      await taskStore.syncFromSupabase()
-                                      await store.syncFromSupabase()
+                                      await taskStore.backupToSupabase()
+                                      await store.backupToSupabase()
+                                      // Çekme sırasını da aynı mantıkla koru
                                       await tagStore.syncFromSupabase()
                                       await projectStore.syncFromSupabase()
+                                      await taskStore.syncFromSupabase()
+                                      await store.syncFromSupabase()
                                   }
                               }) {
                                   Image(systemName: "arrow.clockwise")
@@ -107,10 +109,10 @@ public struct CalendarPage: View {
             }
             .sheet(isPresented: $showKanban) { KanbanPage(store: taskStore) }
             .task {
-                await taskStore.syncFromSupabase()
-                await store.syncFromSupabase()
                 await tagStore.syncFromSupabase()
                 await projectStore.syncFromSupabase()
+                await taskStore.syncFromSupabase()
+                await store.syncFromSupabase()
             }
             .background(Theme.primaryBG.ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- Ensure calendar backup uploads tags/projects before tasks/events
- Sync stores in same order on view load so Kanban reflects changes

## Testing
- `swiftc -typecheck ios/Views/Calendar/CalendarPage.swift ios/Services/EventStore.swift ios/Services/TaskStore.swift ios/Services/TagStore.swift ios/Services/ProjectStore.swift ios/Services/SyncOrchestrator.swift ios/Services/SupabaseService.swift ios/Views/Kanban/KanbanPage.swift`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab1486a38c832891c23299069f458d