### PR TITLE
Fix backup flow and robust Kanban drops

### DIFF
--- a/ios/Services/EventStore.swift
+++ b/ios/Services/EventStore.swift
@@ -47,4 +47,8 @@ public final class EventStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertEvents(events)
     }
+
+    public func replaceSupabaseWithLocal() async {
+        try? await SupabaseService.shared.replaceEvents(events)
+    }
 }

--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -33,4 +33,8 @@ public final class TaskStore: ObservableObject {
     public func backupToSupabase() async {
         try? await SupabaseService.shared.upsertTasks(tasks)
     }
+
+    public func replaceSupabaseWithLocal() async {
+        try? await SupabaseService.shared.replaceTasks(tasks)
+    }
 }

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -88,16 +88,18 @@ public struct CalendarPage: View {
                               }
                               Button(action: {
                                   Task {
-                                      // Foreign key bütünlüğü için önce tag ve projeler, sonra görevler ve etkinlikler
-                                      await tagStore.backupToSupabase()
-                                      await projectStore.backupToSupabase()
-                                      await taskStore.backupToSupabase()
-                                      await store.backupToSupabase()
-                                      // Çekme sırasını da aynı mantıkla koru
-                                      await tagStore.syncFromSupabase()
-                                      await projectStore.syncFromSupabase()
-                                      await taskStore.syncFromSupabase()
-                                      await store.syncFromSupabase()
+                                      await SyncOrchestrator.replaceRemoteWithLocal(
+                                          tags: tagStore,
+                                          projects: projectStore,
+                                          tasks: taskStore,
+                                          events: store
+                                      )
+                                      await SyncOrchestrator.initialPull(
+                                          tags: tagStore,
+                                          projects: projectStore,
+                                          tasks: taskStore,
+                                          events: store
+                                      )
                                   }
                               }) {
                                   Image(systemName: "arrow.clockwise")

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -58,7 +58,7 @@ private struct KanbanColumn: View {
                 }
                 .padding(8)
             }
-            .frame(height: 200)
+            .frame(minHeight: 240)
             .background(Theme.secondaryBG)
             .clipShape(RoundedRectangle(cornerRadius: 8))
             .onDrop(of: [.text], delegate: DropHandler(onDropTask: onDropTask))
@@ -72,9 +72,11 @@ private struct KanbanColumn: View {
         func performDrop(info: DropInfo) -> Bool {
             guard let provider = info.itemProviders(for: [.text]).first else { return false }
             provider.loadItem(forTypeIdentifier: UTType.text.identifier, options: nil) { item, _ in
-                if let data = item as? Data,
-                   let str = String(data: data, encoding: .utf8),
-                   let id = Int(str) {
+                let idString: String? =
+                    (item as? Data).flatMap { String(data: $0, encoding: .utf8) } ??
+                    (item as? String) ??
+                    (item as? NSString).map { String($0) }
+                if let id = idString.flatMap(Int.init) {
                     DispatchQueue.main.async { onDropTask(id) }
                 }
             }


### PR DESCRIPTION
## Summary
- Replace Backup button with replaceRemoteWithLocal orchestrator followed by fresh pull
- Support robust text decoding in Kanban drag-and-drop and enlarge list area
- Add replaceSupabaseWithLocal helpers to EventStore and TaskStore

## Testing
- `pytest`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab196870848328ac89c49abd3fd227