### PR TITLE
Resolve TaskStore tasks(for:) redeclaration

### DIFF
--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -98,15 +98,15 @@ public final class TaskStore: ObservableObject {
     }
     
     // Filtreleme yardımcıları
-    public func tasks(for status: String) -> [PlannerTask] {
+    public func tasks(forStatus status: String) -> [PlannerTask] {
         tasks.filter { normalizeStatus($0.status) == status }
     }
-    
-    public func tasks(for tag: String) -> [PlannerTask] {
+
+    public func tasks(forTag tag: String) -> [PlannerTask] {
         tasks.filter { $0.tag == tag }
     }
-    
-    public func tasks(for project: String) -> [PlannerTask] {
+
+    public func tasks(forProject project: String) -> [PlannerTask] {
         tasks.filter { $0.project == project }
     }
     


### PR DESCRIPTION
## Summary
- Rename TaskStore helper methods to `tasks(forStatus:)`, `tasks(forTag:)`, and `tasks(forProject:)` to avoid duplicate signatures

## Testing
- `swiftc ios/Services/TaskStore.swift -o /tmp/taskstore.out` *(fails: no such module 'SwiftUI')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab420d50ec8328ab33555d13a3db75