### PR TITLE
Use environment objects for shared stores and simplify backup

### DIFF
--- a/ios/App/PersonalAssistantApp.swift
+++ b/ios/App/PersonalAssistantApp.swift
@@ -2,9 +2,18 @@ import SwiftUI
 
 @main
 struct PersonalAssistantApp: App {
+    @StateObject private var eventStore = EventStore()
+    @StateObject private var taskStore = TaskStore()
+    @StateObject private var tagStore = TagStore()
+    @StateObject private var projectStore = ProjectStore()
+
     var body: some Scene {
         WindowGroup {
             RootTabView()
+                .environmentObject(eventStore)
+                .environmentObject(taskStore)
+                .environmentObject(tagStore)
+                .environmentObject(projectStore)
         }
     }
 }

--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 public struct CalendarPage: View {
-    @StateObject private var store = EventStore()
-    @StateObject private var taskStore = TaskStore()
-    @StateObject private var tagStore = TagStore()
-    @StateObject private var projectStore = ProjectStore()
+    @EnvironmentObject private var store: EventStore
+    @EnvironmentObject private var taskStore: TaskStore
+    @EnvironmentObject private var tagStore: TagStore
+    @EnvironmentObject private var projectStore: ProjectStore
     @State private var selectedDate = Date()
     @State private var showKanban = false
     @State private var mode: Mode = .week
@@ -58,12 +58,10 @@ public struct CalendarPage: View {
                              tag: selectedTag,
                              project: selectedProject)
                     .padding(.horizontal, H)
-                    .environmentObject(store)
                 } else {
                     DayTimelineView(date: selectedDate,
                                     events: filteredEvents(for: selectedDate))
                     .padding(.horizontal, H)
-                    .environmentObject(store)
                 }
             }
             .toolbar {
@@ -106,7 +104,7 @@ public struct CalendarPage: View {
                 }
             }
             .sheet(isPresented: $showKanban) {
-                KanbanPage(taskStore: taskStore, tagStore: tagStore, projectStore: projectStore)
+                KanbanPage()
             }
             .task {
                 await initialLoad()
@@ -160,14 +158,6 @@ public struct CalendarPage: View {
 
         // Local verileri Supabase'e yaz (tamamen yer değiştir)
         await SyncOrchestrator.replaceRemoteWithLocal(
-            tags: tagStore,
-            projects: projectStore,
-            tasks: taskStore,
-            events: store
-        )
-
-        // Sonrasında güncel verileri tekrar çek
-        await SyncOrchestrator.initialPull(
             tags: tagStore,
             projects: projectStore,
             tasks: taskStore,

--- a/ios/Views/Kanban/KanbanPage.swift
+++ b/ios/Views/Kanban/KanbanPage.swift
@@ -96,19 +96,15 @@ private struct KanbanColumn: View {
 }
 
 public struct KanbanPage: View {
-    @ObservedObject var taskStore: TaskStore
-    @ObservedObject var tagStore: TagStore
-    @ObservedObject var projectStore: ProjectStore
+    @EnvironmentObject var taskStore: TaskStore
+    @EnvironmentObject var tagStore: TagStore
+    @EnvironmentObject var projectStore: ProjectStore
     @State private var selectedTag: String?
     @State private var selectedProject: String?
     @State private var showingAddTask = false
     @State private var isRefreshing = false
-    
-    public init(taskStore: TaskStore, tagStore: TagStore, projectStore: ProjectStore) {
-        self.taskStore = taskStore
-        self.tagStore = tagStore
-        self.projectStore = projectStore
-    }
+
+    public init() {}
     
     public var body: some View {
         VStack {
@@ -224,9 +220,6 @@ public struct KanbanPage: View {
         }
         .sheet(isPresented: $showingAddTask) {
             AddTaskSheet(
-                taskStore: taskStore,
-                tagStore: tagStore,
-                projectStore: projectStore,
                 preSelectedTag: selectedTag,
                 preSelectedProject: selectedProject
             )
@@ -280,10 +273,10 @@ public struct KanbanPage: View {
 }
 
 private struct AddTaskSheet: View {
-    @ObservedObject var taskStore: TaskStore
-    @ObservedObject var tagStore: TagStore
-    @ObservedObject var projectStore: ProjectStore
-    
+    @EnvironmentObject var taskStore: TaskStore
+    @EnvironmentObject var tagStore: TagStore
+    @EnvironmentObject var projectStore: ProjectStore
+
     @State private var title = ""
     @State private var notes = ""
     @State private var selectedStatus = "todo"
@@ -291,17 +284,22 @@ private struct AddTaskSheet: View {
     @State private var selectedProject: String?
     @State private var hasDueDate = false
     @State private var dueDate = Date()
-    
+
     var preSelectedTag: String?
     var preSelectedProject: String?
-    
+
     @Environment(\.dismiss) private var dismiss
-    
+
     private let statusOptions = [
         ("todo", "Yapılacak"),
         ("doing", "Yapılıyor"),
         ("done", "Bitti")
     ]
+
+    init(preSelectedTag: String?, preSelectedProject: String?) {
+        self.preSelectedTag = preSelectedTag
+        self.preSelectedProject = preSelectedProject
+    }
     
     var body: some View {
         NavigationView {


### PR DESCRIPTION
## Summary
- Lift Task, Tag, Project, and Event stores to app scope and inject them via `EnvironmentObject`.
- Update Calendar and Kanban pages to consume shared environment stores.
- Remove redundant pull step in backup routine to avoid unnecessary sync.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab608b41548328810579613d31da73