### PR TITLE
Fix reserved keyword usage in CalendarPage overlaps guard

### DIFF
--- a/ios/Views/Calendar/CalendarPage.swift
+++ b/ios/Views/Calendar/CalendarPage.swift
@@ -292,8 +292,8 @@ private struct DayColumnView: View {
     }
 
     private func overlaps(_ a: PlannerTask, _ b: PlannerTask) -> Bool {
-        guard let as = a.start, let ae = a.end, let bs = b.start, let be = b.end else { return false }
-        return as < be && bs < ae
+        guard let aStart = a.start, let aEnd = a.end, let bStart = b.start, let bEnd = b.end else { return false }
+        return aStart < bEnd && bStart < aEnd
     }
 
     private func isSmallestInCluster(_ ev: PlannerTask, in events: [PlannerTask]) -> Bool {


### PR DESCRIPTION
## Summary
- Replace reserved keyword variable names in CalendarPage.overlaps to avoid Swift syntax errors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69f2d95c8328bb9c0143a8bb74d0