### PR TITLE
refactor: improve supabase sync and local stores

### DIFF
--- a/ios/Services/ProjectStore.swift
+++ b/ios/Services/ProjectStore.swift
@@ -27,13 +27,17 @@ public final class ProjectStore: ObservableObject {
 
     public func load() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
-        if let decoded = try? JSONDecoder().decode([PlannerProject].self, from: data) {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if let decoded = try? decoder.decode([PlannerProject].self, from: data) {
             projects = decoded
         }
     }
 
     public func save() {
-        if let data = try? JSONEncoder().encode(projects) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(projects) {
             try? data.write(to: fileURL)
         }
 

--- a/ios/Services/TagStore.swift
+++ b/ios/Services/TagStore.swift
@@ -27,13 +27,17 @@ public final class TagStore: ObservableObject {
 
     public func load() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
-        if let decoded = try? JSONDecoder().decode([PlannerTag].self, from: data) {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if let decoded = try? decoder.decode([PlannerTag].self, from: data) {
             tags = decoded
         }
     }
 
     public func save() {
-        if let data = try? JSONEncoder().encode(tags) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(tags) {
             try? data.write(to: fileURL)
         }
 

--- a/ios/Services/TaskStore.swift
+++ b/ios/Services/TaskStore.swift
@@ -29,16 +29,20 @@ public final class TaskStore: ObservableObject {
 
     public func load() {
         guard let data = try? Data(contentsOf: fileURL) else { return }
-        if let decoded = try? JSONDecoder().decode([PlannerTask].self, from: data) {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if let decoded = try? decoder.decode([PlannerTask].self, from: data) {
             tasks = decoded
         }
     }
 
     public func save() {
-        if let data = try? JSONEncoder().encode(tasks) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(tasks) {
             try? data.write(to: fileURL)
         }
-        
+
         // Değişiklik bildirimi gönder
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .tasksDidUpdate, object: self)


### PR DESCRIPTION
## Summary
- handle flexible ISO8601 dates for tags and projects
- batch task upserts and support parent relationships
- persist local stores using ISO8601 encoding

## Testing
- `swiftc ios/Services/SupabaseService.swift ios/Models/Task.swift ios/Models/Tag.swift ios/Models/Project.swift -typecheck` *(fails: cannot find type 'DayEnergy' in scope)*
- `swiftc ios/Services/TaskStore.swift -typecheck` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9693f84083288b0f5c9a1c67d1e7